### PR TITLE
feat(web): migrate routes from software name to ID

### DIFF
--- a/web/src/core/usecases/declarationForm/thunks.ts
+++ b/web/src/core/usecases/declarationForm/thunks.ts
@@ -8,9 +8,9 @@ import { name, actions, type State, type FormData } from "./state";
 
 export const thunks = {
     initialize:
-        (params: { softwareName: string }) =>
+        (params: { softwareId: number }) =>
         async (...args) => {
-            const { softwareName } = params;
+            const { softwareId } = params;
 
             const [dispatch, getState, { sillApi }] = args;
 
@@ -30,7 +30,7 @@ export const thunks = {
             dispatch(actions.initializationStarted());
 
             const software = (await sillApi.getSoftwareList()).find(
-                software => software.softwareName === softwareName
+                software => software.id === softwareId
             );
 
             assert(software !== undefined);
@@ -39,7 +39,7 @@ export const thunks = {
                 actions.initializationCompleted({
                     software: {
                         logoUrl: software.logoUrl,
-                        softwareName,
+                        softwareName: software.softwareName,
                         softwareId: software.id,
                         referentCount: Object.values(
                             software.userAndReferentCountByOrganization

--- a/web/src/core/usecases/instanceForm/thunks.ts
+++ b/web/src/core/usecases/instanceForm/thunks.ts
@@ -17,7 +17,7 @@ export const thunks = {
                   }
                 | {
                       type: "create";
-                      softwareName: string | undefined;
+                      softwareId: number | undefined;
                   }
         ) =>
         async (...args) => {
@@ -77,11 +77,10 @@ export const thunks = {
                     break;
                 case "create":
                     const software =
-                        params.softwareName === undefined
+                        params.softwareId === undefined
                             ? undefined
                             : softwares.find(
-                                  software =>
-                                      software.softwareName === params.softwareName
+                                  software => software.id === params.softwareId
                               );
 
                     assert(currentUser);

--- a/web/src/core/usecases/softwareForm/thunks.ts
+++ b/web/src/core/usecases/softwareForm/thunks.ts
@@ -20,7 +20,7 @@ export const thunks = {
                   }
                 | {
                       scenario: "update";
-                      softwareName: string;
+                      softwareId: number;
                   }
         ) =>
         async (...args) => {
@@ -77,18 +77,13 @@ export const thunks = {
                     break;
                 case "update":
                     {
-                        const softwareList = await sillApi.getSoftwareList();
-                        const softwareFromList = softwareList.find(
-                            s => s.softwareName === params.softwareName
-                        );
-
-                        assert(softwareFromList !== undefined);
-
                         const software = await sillApi.getSoftwareDetails({
-                            softwareId: softwareFromList.id
+                            softwareId: params.softwareId
                         });
 
                         assert(software !== undefined);
+
+                        const softwareList = await sillApi.getSoftwareList();
 
                         dispatch(
                             actions.initializedForUpdate({

--- a/web/src/core/usecases/softwareUserAndReferent/selectors.ts
+++ b/web/src/core/usecases/softwareUserAndReferent/selectors.ts
@@ -18,27 +18,35 @@ const readyState = (rootState: RootState) => {
 };
 
 const isReady = createSelector(readyState, readyState => readyState !== undefined);
+const softwareId = createSelector(readyState, readyState => readyState?.softwareId);
+const softwareName = createSelector(readyState, readyState => readyState?.softwareName);
 const logoUrl = createSelector(readyState, readyState => readyState?.logoUrl);
 const users = createSelector(readyState, readyState => readyState?.users);
 const referents = createSelector(readyState, readyState => readyState?.referents);
 
 const main = createSelector(
     isReady,
+    softwareId,
+    softwareName,
     logoUrl,
     users,
     referents,
-    (isReady, logoUrl, users, referents) => {
+    (isReady, softwareId, softwareName, logoUrl, users, referents) => {
         if (!isReady) {
             return {
                 isReady: false as const
             };
         }
 
+        assert(softwareId !== undefined);
+        assert(softwareName !== undefined);
         assert(users !== undefined);
         assert(referents !== undefined);
 
         return {
             isReady: true as const,
+            softwareId,
+            softwareName,
             logoUrl,
             users,
             referents

--- a/web/src/core/usecases/softwareUserAndReferent/state.ts
+++ b/web/src/core/usecases/softwareUserAndReferent/state.ts
@@ -16,6 +16,7 @@ export namespace State {
 
     export type Ready = {
         stateDescription: "ready";
+        softwareId: number;
         softwareName: string;
         logoUrl: string | undefined;
         users: SoftwareUser[];
@@ -61,6 +62,7 @@ export const { reducer, actions } = createUsecaseActions({
                 payload
             }: {
                 payload: {
+                    softwareId: number;
                     softwareName: string;
                     logoUrl: string | undefined;
                     users: State.SoftwareUser[];
@@ -68,10 +70,11 @@ export const { reducer, actions } = createUsecaseActions({
                 };
             }
         ) => {
-            const { softwareName, logoUrl, users, referents } = payload;
+            const { softwareId, softwareName, logoUrl, users, referents } = payload;
 
             return {
                 stateDescription: "ready",
+                softwareId,
                 softwareName,
                 logoUrl,
                 users,

--- a/web/src/core/usecases/softwareUserAndReferent/thunks.ts
+++ b/web/src/core/usecases/softwareUserAndReferent/thunks.ts
@@ -9,9 +9,9 @@ import { name, actions, type State } from "./state";
 
 export const thunks = {
     initialize:
-        (params: { softwareName: string }) =>
+        (params: { softwareId: number }) =>
         async (...args) => {
-            const { softwareName } = params;
+            const { softwareId } = params;
 
             const [dispatch, getState, { sillApi }] = args;
 
@@ -24,6 +24,14 @@ export const thunks = {
             }
 
             dispatch(actions.initializationStarted());
+
+            const software = (await sillApi.getSoftwareList()).find(
+                software => software.id === softwareId
+            );
+
+            assert(software !== undefined);
+
+            const softwareName = software.softwareName;
 
             const { users } = await sillApi.getUsers();
 
@@ -82,14 +90,9 @@ export const thunks = {
                 }
             }
 
-            const software = (await sillApi.getSoftwareList()).find(
-                software => software.softwareName === softwareName
-            );
-
-            assert(software !== undefined);
-
             dispatch(
                 actions.initializationCompleted({
+                    softwareId,
                     softwareName,
                     logoUrl: software.logoUrl,
                     users: softwareUsers,

--- a/web/src/ui/pages/declarationForm/DeclarationForm.tsx
+++ b/web/src/ui/pages/declarationForm/DeclarationForm.tsx
@@ -48,9 +48,9 @@ export default function DeclarationForm(props: Props) {
     );
 
     useEffect(() => {
-        declarationForm.initialize({ softwareName: route.params.name });
+        declarationForm.initialize({ softwareId: route.params.id });
         return () => declarationForm.clear();
-    }, []);
+    }, [route.params.id]);
 
     useEffect(() => {
         const { declarationType } = route.params;
@@ -157,7 +157,7 @@ export default function DeclarationForm(props: Props) {
                             )}
                             seeUserAndReferent={
                                 routes.softwareUsersAndReferents({
-                                    name: software.softwareName
+                                    id: software.softwareId
                                 }).link
                             }
                             referentCount={software.referentCount}

--- a/web/src/ui/pages/declarationForm/route.ts
+++ b/web/src/ui/pages/declarationForm/route.ts
@@ -16,7 +16,7 @@ import { appPath } from "urls";
 export const routeDefs = {
     declarationForm: defineRoute(
         {
-            name: param.query.string,
+            id: param.query.number,
             declarationType: param.query.optional.ofType({
                 parse: raw => {
                     const schema = z.union([z.literal("user"), z.literal("referent")]);

--- a/web/src/ui/pages/instanceForm/InstanceForm.tsx
+++ b/web/src/ui/pages/instanceForm/InstanceForm.tsx
@@ -54,7 +54,7 @@ export default function InstanceForm(props: Props) {
                     case "instanceCreationForm":
                         return {
                             type: "create",
-                            softwareName: route.params.softwareName
+                            softwareId: route.params.softwareId
                         };
                     case "instanceUpdateForm":
                         return {
@@ -66,7 +66,7 @@ export default function InstanceForm(props: Props) {
         );
 
         return () => instanceForm.clear();
-    }, [route.name]);
+    }, [route.name, route.params]);
 
     useEvt(
         ctx =>

--- a/web/src/ui/pages/instanceForm/route.ts
+++ b/web/src/ui/pages/instanceForm/route.ts
@@ -8,7 +8,7 @@ import { appPath } from "urls";
 export const routeDefs = {
     instanceCreationForm: defineRoute(
         {
-            softwareName: param.query.optional.string
+            softwareId: param.query.optional.number
         },
         () => appPath + "/add-instance"
     ),

--- a/web/src/ui/pages/redirect/Redirect.tsx
+++ b/web/src/ui/pages/redirect/Redirect.tsx
@@ -27,6 +27,14 @@ export default function Redirect(props: Props) {
         Object.entries(softwareNameBySillId).map(([id, name]) => [name, parseInt(id)])
     );
 
+    const getSoftwareIdByNameOrRedirect404 = (name: string): number | undefined => {
+        const softwareId = sillIdBySoftwareName[name];
+        if (softwareId === undefined) {
+            routes.page404().replace();
+        }
+        return softwareId;
+    };
+
     useEffect(() => {
         switch (route.name) {
             case "ogSill":
@@ -71,30 +79,64 @@ export default function Redirect(props: Props) {
                 break;
             case "onyxiaUiSillCard":
                 {
-                    const { name } = route.params;
-
-                    const softwareId = sillIdBySoftwareName[name];
-
-                    if (softwareId === undefined) {
-                        routes.page404().replace();
-                        return;
-                    }
+                    const softwareId = getSoftwareIdByNameOrRedirect404(
+                        route.params.name
+                    );
+                    if (softwareId === undefined) return;
 
                     routes.softwareDetails({ id: softwareId }).replace();
                 }
                 break;
             case "softwareDetailsByName":
                 {
-                    const { name } = route.params;
-
-                    const softwareId = sillIdBySoftwareName[name];
-
-                    if (softwareId === undefined) {
-                        routes.page404().replace();
-                        return;
-                    }
+                    const softwareId = getSoftwareIdByNameOrRedirect404(
+                        route.params.name
+                    );
+                    if (softwareId === undefined) return;
 
                     routes.softwareDetails({ id: softwareId }).replace();
+                }
+                break;
+            case "softwareUsersAndReferentsByName":
+                {
+                    const softwareId = getSoftwareIdByNameOrRedirect404(
+                        route.params.name
+                    );
+                    if (softwareId === undefined) return;
+
+                    routes.softwareUsersAndReferents({ id: softwareId }).replace();
+                }
+                break;
+            case "declarationFormByName":
+                {
+                    const { declarationType } = route.params;
+
+                    const softwareId = getSoftwareIdByNameOrRedirect404(
+                        route.params.name
+                    );
+                    if (softwareId === undefined) return;
+
+                    routes.declarationForm({ id: softwareId, declarationType }).replace();
+                }
+                break;
+            case "softwareUpdateFormByName":
+                {
+                    const softwareId = getSoftwareIdByNameOrRedirect404(
+                        route.params.name
+                    );
+                    if (softwareId === undefined) return;
+
+                    routes.softwareUpdateForm({ id: softwareId }).replace();
+                }
+                break;
+            case "instanceCreationFormBySoftwareName":
+                {
+                    const softwareId = getSoftwareIdByNameOrRedirect404(
+                        route.params.softwareName
+                    );
+                    if (softwareId === undefined) return;
+
+                    routes.instanceCreationForm({ softwareId }).replace();
                 }
                 break;
         }

--- a/web/src/ui/pages/redirect/route.ts
+++ b/web/src/ui/pages/redirect/route.ts
@@ -2,7 +2,15 @@
 // SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
 // SPDX-License-Identifier: MIT
 
-import { createGroup, defineRoute, createRouter, param, type Route } from "type-route";
+import {
+    createGroup,
+    defineRoute,
+    createRouter,
+    param,
+    type Route,
+    noMatch
+} from "type-route";
+import { z } from "zod";
 import { appPath } from "urls";
 
 export const routeDefs = {
@@ -31,6 +39,42 @@ export const routeDefs = {
             name: param.query.string
         },
         () => appPath + `/detail`
+    ),
+    softwareUsersAndReferentsByName: defineRoute(
+        {
+            name: param.query.string
+        },
+        () => appPath + `/users-and-referents`
+    ),
+    declarationFormByName: defineRoute(
+        {
+            name: param.query.string,
+            declarationType: param.query.optional.ofType({
+                parse: raw => {
+                    const schema = z.union([z.literal("user"), z.literal("referent")]);
+
+                    try {
+                        return schema.parse(raw);
+                    } catch {
+                        return noMatch;
+                    }
+                },
+                stringify: value => value
+            })
+        },
+        () => appPath + `/declaration`
+    ),
+    softwareUpdateFormByName: defineRoute(
+        {
+            name: param.query.string
+        },
+        () => appPath + `/update`
+    ),
+    instanceCreationFormBySoftwareName: defineRoute(
+        {
+            softwareName: param.query.string
+        },
+        () => appPath + `/add-instance`
     )
 };
 

--- a/web/src/ui/pages/softwareCatalog/SoftwareCatalog.tsx
+++ b/web/src/ui/pages/softwareCatalog/SoftwareCatalog.tsx
@@ -153,8 +153,8 @@ export default function SoftwareCatalog(props: Props) {
                     /* prettier-ignore */
                     {
                         "softwareDetails": routes.softwareDetails({ "id": id }).link,
-                        "declareUsageForm": routes.declarationForm({ "name": softwareName }).link,
-                        "softwareUsersAndReferents": routes.softwareUsersAndReferents({ "name": softwareName }).link
+                        "declareUsageForm": routes.declarationForm({ "id": id }).link,
+                        "softwareUsersAndReferents": routes.softwareUsersAndReferents({ "id": id }).link
                     }
                 ])
             ),

--- a/web/src/ui/pages/softwareDetails/SoftwareDetails.tsx
+++ b/web/src/ui/pages/softwareDetails/SoftwareDetails.tsx
@@ -164,8 +164,7 @@ export default function SoftwareDetails(props: Props) {
                                                   instanceList={software.instances}
                                                   createInstanceLink={
                                                       routes.instanceCreationForm({
-                                                          softwareName:
-                                                              software.softwareName
+                                                          softwareId: software.softwareId
                                                       }).link
                                                   }
                                               />
@@ -226,24 +225,28 @@ export default function SoftwareDetails(props: Props) {
                                                   similarSoftwares={
                                                       software.similarSoftwares
                                                   }
-                                                  getLinks={({ softwareName }) => ({
-                                                      declarationForm:
-                                                          routes.declarationForm({
-                                                              name: softwareName
-                                                          }).link,
-                                                      softwareDetails:
-                                                          routes.softwareDetails({
-                                                              id: softwareIdByName.get(
-                                                                  softwareName
-                                                              )!
-                                                          }).link,
-                                                      softwareUsersAndReferents:
-                                                          routes.softwareUsersAndReferents(
-                                                              {
-                                                                  name: softwareName
-                                                              }
-                                                          ).link
-                                                  })}
+                                                  getLinks={({ softwareName }) => {
+                                                      const softwareId =
+                                                          softwareIdByName.get(
+                                                              softwareName
+                                                          )!;
+                                                      return {
+                                                          declarationForm:
+                                                              routes.declarationForm({
+                                                                  id: softwareId
+                                                              }).link,
+                                                          softwareDetails:
+                                                              routes.softwareDetails({
+                                                                  id: softwareId
+                                                              }).link,
+                                                          softwareUsersAndReferents:
+                                                              routes.softwareUsersAndReferents(
+                                                                  {
+                                                                      id: softwareId
+                                                                  }
+                                                              ).link
+                                                      };
+                                                  }}
                                                   getAddWikipediaSoftwareToSillLink={({
                                                       externalId
                                                   }) =>
@@ -285,7 +288,7 @@ export default function SoftwareDetails(props: Props) {
                             seeUserAndReferent={
                                 software.referentCount > 0 || software.userCount > 0
                                     ? routes.softwareUsersAndReferents({
-                                          name: software.softwareName
+                                          id: software.softwareId
                                       }).link
                                     : undefined
                             }
@@ -330,7 +333,7 @@ export default function SoftwareDetails(props: Props) {
                                 priority="secondary"
                                 linkProps={
                                     routes.softwareUpdateForm({
-                                        name: software.softwareName
+                                        id: software.softwareId
                                     }).link
                                 }
                             >
@@ -348,7 +351,7 @@ export default function SoftwareDetails(props: Props) {
                                         <Button
                                             linkProps={
                                                 routes.declarationForm({
-                                                    name: software.softwareName
+                                                    id: software.softwareId
                                                 }).link
                                             }
                                         >
@@ -379,7 +382,7 @@ export default function SoftwareDetails(props: Props) {
                                             <Button
                                                 linkProps={
                                                     routes.declarationForm({
-                                                        name: software.softwareName,
+                                                        id: software.softwareId,
                                                         declarationType: "referent"
                                                     }).link
                                                 }

--- a/web/src/ui/pages/softwareForm/SoftwareForm.tsx
+++ b/web/src/ui/pages/softwareForm/SoftwareForm.tsx
@@ -59,14 +59,14 @@ export default function SoftwareForm(props: Props) {
                     case "softwareUpdateForm":
                         return {
                             scenario: "update",
-                            softwareName: route.params.name
+                            softwareId: route.params.id
                         };
                 }
             })()
         );
 
         return () => softwareForm.clear();
-    }, [route.name]);
+    }, [route.name, route.params]);
 
     const { allSoftwares } = useCoreState("softwareCatalog", "main");
 

--- a/web/src/ui/pages/softwareForm/Step2.tsx
+++ b/web/src/ui/pages/softwareForm/Step2.tsx
@@ -253,7 +253,7 @@ export function SoftwareFormStep2(props: Step2Props) {
                                         ),
                                         exampleUrl: (
                                             <a
-                                                href="https://code.gouv.fr/sill/detail?name=Keycloakify"
+                                                href="https://code.gouv.fr/sill/detail?id=243"
                                                 target="_blank"
                                                 rel="noreferrer"
                                             >

--- a/web/src/ui/pages/softwareForm/route.ts
+++ b/web/src/ui/pages/softwareForm/route.ts
@@ -10,10 +10,7 @@ export const routeDefs = {
         { externalId: param.query.optional.string },
         () => appPath + "/add"
     ),
-    softwareUpdateForm: defineRoute(
-        { name: param.query.string },
-        () => appPath + "/update"
-    )
+    softwareUpdateForm: defineRoute({ id: param.query.number }, () => appPath + "/update")
 };
 
 export const routeGroup = createGroup(Object.values(createRouter(routeDefs).routes));

--- a/web/src/ui/pages/softwareUserAndReferent/SoftwareUserAndReferent.tsx
+++ b/web/src/ui/pages/softwareUserAndReferent/SoftwareUserAndReferent.tsx
@@ -27,32 +27,24 @@ export default function SoftwareUserAndReferent(props: Props) {
 
     const { softwareUserAndReferent } = useCore().functions;
 
-    const { isReady, logoUrl, referents, users } = useCoreState(
+    const { isReady, logoUrl, referents, users, softwareId, softwareName } = useCoreState(
         "softwareUserAndReferent",
         "main"
     );
 
-    const { allSoftwares } = useCoreState("softwareCatalog", "main");
-
-    const softwareIdByName = Object.fromEntries(
-        allSoftwares.map(s => [s.softwareName, s.id])
-    );
-
     useEffect(() => {
-        softwareUserAndReferent.initialize({ softwareName: route.params.name });
+        softwareUserAndReferent.initialize({ softwareId: route.params.id });
 
         return () => {
             softwareUserAndReferent.clear();
         };
-    }, [route.params.name]);
+    }, [route.params.id]);
 
     const { classes, cx } = useStyles();
 
     const { t } = useTranslation();
 
     const [activeMenu, setActiveMenu] = useState(0);
-
-    const softwareName = route.params.name;
 
     const { getOrganizationFullName } = useGetOrganizationFullName();
 
@@ -177,9 +169,9 @@ export default function SoftwareUserAndReferent(props: Props) {
                         },
                         {
                             linkProps: routes.softwareDetails({
-                                id: softwareIdByName[softwareName]
+                                id: softwareId
                             }).link,
-                            label: route.params.name
+                            label: softwareName
                         }
                     ]}
                     currentPageLabel={t(
@@ -322,8 +314,7 @@ export default function SoftwareUserAndReferent(props: Props) {
                     iconId="fr-icon-eye-line"
                     priority="secondary"
                     className={classes.softwareDetails}
-                    {...routes.softwareDetails({ id: softwareIdByName[softwareName] })
-                        .link}
+                    {...routes.softwareDetails({ id: softwareId }).link}
                 >
                     {t("softwareUserAndReferent.softwareDetails")}
                 </Button>
@@ -331,7 +322,7 @@ export default function SoftwareUserAndReferent(props: Props) {
                     priority="primary"
                     linkProps={
                         routes.declarationForm({
-                            name: route.params.name,
+                            id: softwareId,
                             declarationType: activeMenu === 0 ? "referent" : "user"
                         }).link
                     }

--- a/web/src/ui/pages/softwareUserAndReferent/route.ts
+++ b/web/src/ui/pages/softwareUserAndReferent/route.ts
@@ -8,7 +8,7 @@ import { appPath } from "urls";
 export const routeDefs = {
     softwareUsersAndReferents: defineRoute(
         {
-            name: param.query.string
+            id: param.query.number
         },
         () => appPath + `/users-and-referents`
     )


### PR DESCRIPTION
## Summary

Migrate 4 frontend routes from using software name to id as URL parameter, while keeping backward-compatible redirects for legacy name-based URLs.

## Routes Migrated

| Route | Before | After |
|-------|--------|-------|
| softwareUsersAndReferents | `?name=JabRef` | `?id=123` |
| declarationForm | `?name=JabRef` | `?id=123` |
| softwareUpdateForm | `?name=JabRef` | `?id=123` |
| instanceCreationForm | `?softwareName=JabRef` | `?softwareId=123` |

## Backward Compatibility

Legacy name-based URLs are handled via new redirect routes that:
- Look up the software ID by name
- Redirect to the new ID-based route
- Return 404 if software name not found

## Changes

- Added 4 legacy redirect route definitions in `redirect/route.ts`
- Added redirect logic for legacy routes in `Redirect.tsx`
- Updated route definitions in 4 route files to use `id` instead of `name`
- Updated usecase thunks to accept `softwareId` instead of `softwareName`
- Updated page components to use new route params
- Updated all link constructions (~15 locations) to use ID-based routes

## No Backend Changes Required

All tRPC endpoints already use `softwareId` (number) - no API changes needed.