### PR TITLE
fix(i18n): fix broken French publicInstanceCount translation

### DIFF
--- a/api/src/rpc/translations/fr_default.json
+++ b/api/src/rpc/translations/fr_default.json
@@ -274,10 +274,10 @@
         "repoLastClosedIssue": "Dernier ticket fermé"
     },
     "referencedInstancesTab": {
-        "publicInstanceCount": "{{instanceCount}} $t(referencedInstancesTab.instance, {\"count\": {{instanceCount}} }) web $t(referencedInstancesTab.maintain, {\"count\": {{instanceCount}} }) par {{organizationCount}} $t(referencedInstancesTab.organization, {\"count\": {{organizationCount}} }) $t(referencedInstancesTab.public, {\"count\": {{organizationCount}} }",
+        "publicInstanceCount": "{{instanceCount}} $t(referencedInstancesTab.instance, {\"count\": {{instanceCount}} }) web $t(referencedInstancesTab.maintain, {\"count\": {{instanceCount}} }) par {{organizationCount}} $t(referencedInstancesTab.organization, {\"count\": {{organizationCount}} }) $t(referencedInstancesTab.public, {\"count\": {{organizationCount}} })",
         "privateInstanceCount": "{{instanceCount}} $t(referencedInstancesTab.instance, {\"count\": {{instanceCount}} }) en accès restreint $t(referencedInstancesTab.maintain, {\"count\": {{instanceCount}} }) par {{organizationCount}} $t(referencedInstancesTab.organization, {\"count\": {{organizationCount}} })",
-        "instance_one": "instance web maintenue",
-        "instance_other": "instances web maintenues",
+        "instance_one": "instance",
+        "instance_other": "instances",
         "maintain_one": "maintenue",
         "maintain_other": "maintenues",
         "organization_one": "organisation",


### PR DESCRIPTION
Missing closing parenthesis on nested $t(referencedInstancesTab.public)
caused raw interpolation to display. Also deduplicated "web maintenues"
which appeared twice due to instance_one/other including words already
in the template string.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
