### PR TITLE
UserInput overrides and source fallback

### DIFF
--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -77,7 +77,9 @@ const seed = async () => {
     await dbApi.user.add(testUser);
 
     console.info("Adding software packages");
-    const softwarePackagesFormData: SoftwareFormData[] = [
+    const softwarePackagesFormDataWithoutNullables: Array<
+        Omit<SoftwareFormData, "isLibreSoftware" | "url" | "codeRepositoryUrl" | "softwareHelp" | "latestVersion">
+    > = [
         {
             name: "React",
             description: "A JavaScript library for building user interfaces.",
@@ -158,6 +160,15 @@ const seed = async () => {
             customAttributes: { versionMin: "0.26.25" }
         }
     ];
+
+    const softwarePackagesFormData: SoftwareFormData[] = softwarePackagesFormDataWithoutNullables.map(formData => ({
+        ...formData,
+        isLibreSoftware: null,
+        url: null,
+        codeRepositoryUrl: null,
+        softwareHelp: null,
+        latestVersion: null
+    }));
 
     for (const formData of softwarePackagesFormData) {
         await UCCreateSofware({ userId, formData });

--- a/api/src/core/adapters/GitHub/getSofrwareFormData.ts
+++ b/api/src/core/adapters/GitHub/getSofrwareFormData.ts
@@ -23,18 +23,23 @@ export const getGitHubSoftwareFOrm: GetSoftwareFormData = memoize(
 
         const formData: SoftwareFormData = {
             name: repoData.full_name,
-            description: repoData?.description ? repoData.description : "",
+            description: null,
             ...resolveOsAndPlatforms(repoData.topics ?? []), // Someting else to rely on ?
             externalIdForSource: repoData.html_url
                 .replace("https://github.com/", "")
                 .replace("git+", "")
                 .replace(".git", ""),
             sourceSlug: source.slug,
-            license: repoData.license?.name ?? "undefined", // TODO 1 case to copyright
+            license: null,
             similarSoftwareExternalDataItems: [],
-            image: undefined,
+            image: null,
             keywords: repoData.topics || [],
-            customAttributes: undefined
+            customAttributes: undefined,
+            isLibreSoftware: null,
+            url: null,
+            codeRepositoryUrl: null,
+            softwareHelp: null,
+            latestVersion: null
         };
 
         return formData;

--- a/api/src/core/adapters/GitLab/getSoftwareFormData.ts
+++ b/api/src/core/adapters/GitLab/getSoftwareFormData.ts
@@ -22,15 +22,20 @@ export const getGitLabSoftwareForm: GetSoftwareFormData = memoize(
 
         const formData: SoftwareFormData = {
             name: project.name,
-            description: project?.description ?? "",
+            description: null,
             ...resolveOsAndPlatforms(project.topics ?? []), // Someting else to rely on ?
             externalIdForSource: project.web_url,
             sourceSlug: source.slug,
-            license: project.license.name ?? "undefined",
+            license: null,
             similarSoftwareExternalDataItems: [],
-            image: project.avatar_url ?? undefined,
+            image: null,
             keywords: project.topics || [],
-            customAttributes: undefined
+            customAttributes: undefined,
+            isLibreSoftware: null,
+            url: null,
+            codeRepositoryUrl: null,
+            softwareHelp: null,
+            latestVersion: null
         };
 
         return formData;

--- a/api/src/core/adapters/comptoirDuLibre/getCDLFormData.ts
+++ b/api/src/core/adapters/comptoirDuLibre/getCDLFormData.ts
@@ -14,20 +14,24 @@ const formatCDLSoftwareToExternalData = async (
     source: Source
 ): Promise<SoftwareFormData> => {
     const keywords = await comptoirDuLibreApi.getKeywords({ comptoirDuLibreId: comptoirSoftware.id });
-    const logoUrl = await comptoirDuLibreApi.getIconUrl({ comptoirDuLibreId: comptoirSoftware.id });
 
     return {
         name: comptoirSoftware.name,
-        description: "",
+        description: null,
         operatingSystems: { "linux": false, "windows": false, "android": false, "ios": false, "mac": false },
         runtimePlatforms: ["desktop"], // TODO Check Mandatory, Incorrect data
         externalIdForSource: comptoirSoftware.id.toString(),
         sourceSlug: source.slug,
-        license: comptoirSoftware.licence,
+        license: null,
         similarSoftwareExternalDataItems: [],
-        image: logoUrl,
+        image: null,
         keywords: keywords,
-        customAttributes: undefined
+        customAttributes: undefined,
+        isLibreSoftware: null,
+        url: null,
+        codeRepositoryUrl: null,
+        softwareHelp: null,
+        latestVersion: null
     };
 };
 

--- a/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.test.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.test.ts
@@ -223,7 +223,11 @@ describe("createPgSoftwareRepository", () => {
             await insertSoftware(db, { name: "Active" });
             await insertSoftware(db, {
                 name: "Dereferenced",
-                dereferencing: JSON.stringify({ reason: "deprecated", time: Date.now() })
+                dereferencing: JSON.stringify({
+                    reason: "deprecated",
+                    time: new Date().toISOString(),
+                    dereferencedByUserId: null
+                })
             });
 
             const list = await repository.getFullList();

--- a/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.test.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.test.ts
@@ -5,6 +5,7 @@
 import { Kysely } from "kysely";
 import { describe, it, beforeEach, expect } from "vitest";
 import { resetDB, testPgUrl } from "../../../../tools/test.helpers";
+import type { SoftwareExtrinsicRow } from "../../../ports/DbApiV2";
 import { Database, USER_INPUT_SOURCE_SLUG } from "./kysely.database";
 import { createPgDialect } from "./kysely.dialect";
 import { createPgSoftwareRepository } from "./createPgSoftwareRepository";
@@ -112,6 +113,60 @@ const insertUser = async (db: Kysely<Database>, email: string, organization: str
         .executeTakeFirstOrThrow();
     return id;
 };
+
+const makeSoftwareUpdate = (
+    addedByUserId: number,
+    overrides: Partial<SoftwareExtrinsicRow> = {}
+): SoftwareExtrinsicRow => ({
+    name: "Updated Software",
+    description: { fr: "Updated Description" },
+    license: "MIT",
+    image: "https://example.com/updated-logo.png",
+    isLibreSoftware: undefined,
+    url: undefined,
+    codeRepositoryUrl: undefined,
+    softwareHelp: undefined,
+    latestVersion: undefined,
+    dereferencing: undefined,
+    isStillInObservation: false,
+    customAttributes: {},
+    addedByUserId,
+    keywords: [],
+    programmingLanguages: undefined,
+    applicationCategories: [],
+    operatingSystems: {},
+    runtimePlatforms: ["cloud"],
+    userInputOverrides: {},
+    ...overrides
+});
+
+const getAddedByUserId = async (db: Kysely<Database>, softwareId: number) =>
+    db
+        .selectFrom("softwares")
+        .select("addedByUserId")
+        .where("id", "=", softwareId)
+        .executeTakeFirstOrThrow()
+        .then(({ addedByUserId }) => addedByUserId);
+
+const getUserInputRow = async (db: Kysely<Database>, softwareId: number) =>
+    db
+        .selectFrom("software_external_datas")
+        .selectAll()
+        .where("softwareId", "=", softwareId)
+        .where("sourceSlug", "=", USER_INPUT_SOURCE_SLUG)
+        .executeTakeFirstOrThrow();
+
+const insertExternalLicense = async (db: Kysely<Database>, softwareId: number, license: string) =>
+    db
+        .insertInto("software_external_datas")
+        .values({
+            softwareId,
+            sourceSlug: "high_prio",
+            externalId: `ext_license_${softwareId}`,
+            license,
+            authors: JSON.stringify([])
+        })
+        .execute();
 
 describe("createPgSoftwareRepository", () => {
     let db: Kysely<Database>;
@@ -334,6 +389,117 @@ describe("createPgSoftwareRepository", () => {
             // I'll assume standard columns.
 
             expect(details?.externalId).toBe("ext_high"); // High priority external ID
+        });
+
+        it("unions and deduplicates UserInput and external keywords", async () => {
+            const softwareId = await insertSoftware(db, {
+                keywords: JSON.stringify(["manual", "shared"])
+            });
+
+            await db
+                .insertInto("software_external_datas")
+                .values({
+                    softwareId,
+                    sourceSlug: "high_prio",
+                    externalId: "ext_keywords",
+                    keywords: JSON.stringify(["external", "shared"]),
+                    authors: JSON.stringify([])
+                })
+                .execute();
+
+            const details = await repository.getDetails(softwareId);
+            expect(details?.keywords).toEqual(["manual", "shared", "external"]);
+        });
+    });
+
+    describe("update", () => {
+        const updateSoftware = async (softwareId: number, overrides: Partial<SoftwareExtrinsicRow>) =>
+            repository.update({
+                softwareId,
+                software: makeSoftwareUpdate(await getAddedByUserId(db, softwareId), overrides)
+            });
+
+        it.each([
+            {
+                label: "writes a scalar UserInput override when the flag changes from false to true",
+                initialUserInputLicense: null,
+                overrideFlag: true,
+                expectedStoredLicense: "MIT",
+                expectedMergedLicense: "MIT"
+            },
+            {
+                label: "clears a scalar UserInput override when the flag changes from true to false",
+                initialUserInputLicense: "MIT",
+                overrideFlag: false,
+                expectedStoredLicense: null,
+                expectedMergedLicense: "Apache-2.0"
+            }
+        ])(
+            "$label",
+            async ({ initialUserInputLicense, overrideFlag, expectedStoredLicense, expectedMergedLicense }) => {
+                const softwareId = await insertSoftware(db, { license: initialUserInputLicense });
+                await insertExternalLicense(db, softwareId, "Apache-2.0");
+
+                await updateSoftware(softwareId, {
+                    license: "MIT",
+                    userInputOverrides: { license: overrideFlag }
+                });
+
+                expect((await getUserInputRow(db, softwareId)).license).toBe(expectedStoredLicense);
+                expect((await repository.getDetails(softwareId))?.license).toBe(expectedMergedLicense);
+            }
+        );
+
+        it("preserves omitted web scalar override fields for partial API update payloads", async () => {
+            const softwareId = await insertSoftware(db, {
+                name: "Original Name",
+                description: JSON.stringify({ fr: "Manual Description" }),
+                license: "Apache-2.0",
+                image: "https://example.com/original-logo.png"
+            });
+
+            await updateSoftware(softwareId, {
+                name: "Renamed Software",
+                userInputOverrides: { name: true }
+            });
+
+            const userInputRow = await getUserInputRow(db, softwareId);
+
+            expect(userInputRow.name).toEqual({ fr: "Renamed Software" });
+            expect(userInputRow.description).toEqual({ fr: "Manual Description" });
+            expect(userInputRow.license).toBe("Apache-2.0");
+            expect(userInputRow.image).toBe("https://example.com/original-logo.png");
+
+            const details = await repository.getDetails(softwareId);
+            expect(details?.description).toEqual({ fr: "Manual Description" });
+            expect(details?.license).toBe("Apache-2.0");
+            expect(details?.image).toBe("https://example.com/original-logo.png");
+        });
+
+        it("preserves non-web UserInput override fields when web-only flags are submitted", async () => {
+            const preservedLatestVersion = { version: "2.3.4", releaseDate: "2026-01-02" };
+            const softwareId = await insertSoftware(db, {
+                url: "https://manual.example.com",
+                latestVersion: JSON.stringify(preservedLatestVersion)
+            });
+
+            await updateSoftware(softwareId, {
+                userInputOverrides: {
+                    name: false,
+                    description: false,
+                    license: false,
+                    image: false
+                }
+            });
+
+            const userInputRow = await getUserInputRow(db, softwareId);
+
+            expect(userInputRow.url).toBe("https://manual.example.com");
+            expect(userInputRow.latestVersion).toEqual(preservedLatestVersion);
+
+            const details = await repository.getDetails(softwareId);
+            expect(details?.url).toBe("https://manual.example.com");
+            expect(details?.latestVersion).toEqual(preservedLatestVersion);
         });
     });
 });

--- a/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.test.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.test.ts
@@ -122,11 +122,11 @@ const makeSoftwareUpdate = (
     description: { fr: "Updated Description" },
     license: "MIT",
     image: "https://example.com/updated-logo.png",
-    isLibreSoftware: undefined,
-    url: undefined,
-    codeRepositoryUrl: undefined,
-    softwareHelp: undefined,
-    latestVersion: undefined,
+    isLibreSoftware: null,
+    url: null,
+    codeRepositoryUrl: null,
+    softwareHelp: null,
+    latestVersion: null,
     dereferencing: undefined,
     isStillInObservation: false,
     customAttributes: {},
@@ -136,7 +136,6 @@ const makeSoftwareUpdate = (
     applicationCategories: [],
     operatingSystems: {},
     runtimePlatforms: ["cloud"],
-    userInputOverrides: {},
     ...overrides
 });
 
@@ -425,28 +424,27 @@ describe("createPgSoftwareRepository", () => {
 
         it.each([
             {
-                label: "writes a scalar UserInput override when the flag changes from false to true",
+                label: "writes a scalar UserInput override when the form value is non-null",
                 initialUserInputLicense: null,
-                overrideFlag: true,
+                submittedLicense: "MIT",
                 expectedStoredLicense: "MIT",
                 expectedMergedLicense: "MIT"
             },
             {
-                label: "clears a scalar UserInput override when the flag changes from true to false",
+                label: "clears a scalar UserInput override when the form value is null",
                 initialUserInputLicense: "MIT",
-                overrideFlag: false,
+                submittedLicense: null,
                 expectedStoredLicense: null,
                 expectedMergedLicense: "Apache-2.0"
             }
         ])(
             "$label",
-            async ({ initialUserInputLicense, overrideFlag, expectedStoredLicense, expectedMergedLicense }) => {
+            async ({ initialUserInputLicense, submittedLicense, expectedStoredLicense, expectedMergedLicense }) => {
                 const softwareId = await insertSoftware(db, { license: initialUserInputLicense });
                 await insertExternalLicense(db, softwareId, "Apache-2.0");
 
                 await updateSoftware(softwareId, {
-                    license: "MIT",
-                    userInputOverrides: { license: overrideFlag }
+                    license: submittedLicense
                 });
 
                 expect((await getUserInputRow(db, softwareId)).license).toBe(expectedStoredLicense);
@@ -454,7 +452,7 @@ describe("createPgSoftwareRepository", () => {
             }
         );
 
-        it("preserves omitted web scalar override fields for partial API update payloads", async () => {
+        it("always writes the form name to the UserInput row", async () => {
             const softwareId = await insertSoftware(db, {
                 name: "Original Name",
                 description: JSON.stringify({ fr: "Manual Description" }),
@@ -463,24 +461,15 @@ describe("createPgSoftwareRepository", () => {
             });
 
             await updateSoftware(softwareId, {
-                name: "Renamed Software",
-                userInputOverrides: { name: true }
+                name: "Renamed Software"
             });
 
             const userInputRow = await getUserInputRow(db, softwareId);
 
             expect(userInputRow.name).toEqual({ fr: "Renamed Software" });
-            expect(userInputRow.description).toEqual({ fr: "Manual Description" });
-            expect(userInputRow.license).toBe("Apache-2.0");
-            expect(userInputRow.image).toBe("https://example.com/original-logo.png");
-
-            const details = await repository.getDetails(softwareId);
-            expect(details?.description).toEqual({ fr: "Manual Description" });
-            expect(details?.license).toBe("Apache-2.0");
-            expect(details?.image).toBe("https://example.com/original-logo.png");
         });
 
-        it("preserves non-web UserInput override fields when web-only flags are submitted", async () => {
+        it("preserves non-web UserInput fields when the form submits their current values", async () => {
             const preservedLatestVersion = { version: "2.3.4", releaseDate: "2026-01-02" };
             const softwareId = await insertSoftware(db, {
                 url: "https://manual.example.com",
@@ -488,12 +477,8 @@ describe("createPgSoftwareRepository", () => {
             });
 
             await updateSoftware(softwareId, {
-                userInputOverrides: {
-                    name: false,
-                    description: false,
-                    license: false,
-                    image: false
-                }
+                url: "https://manual.example.com",
+                latestVersion: preservedLatestVersion
             });
 
             const userInputRow = await getUserInputRow(db, softwareId);

--- a/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.ts
@@ -5,7 +5,13 @@
 import { Kysely, sql } from "kysely";
 import { DatabaseDataType, PopulatedExternalData, SoftwareRepository } from "../../../ports/DbApiV2";
 import type { LocalizedString } from "../../../ports/GetSoftwareExternalData";
-import { SoftwareInList, Software, SoftwareDetail, SoftwareSourceData } from "../../../usecases/readWriteSillData";
+import {
+    SoftwareInList,
+    Software,
+    SoftwareDetail,
+    SoftwareSourceData,
+    SoftwareUserInputOverrides
+} from "../../../usecases/readWriteSillData";
 import type { Os, RuntimePlatform, SimilarSoftware } from "../../../types";
 import { Database, USER_INPUT_SOURCE_SLUG } from "./kysely.database";
 import { stripNullOrUndefinedValues, transformNullToUndefined } from "./kysely.utils";
@@ -79,11 +85,13 @@ const aggregateEnrichedSimilars = (rows: EnrichedSimilarRow[]): Record<number, S
         {} as Record<number, SimilarSoftware[]>
     );
 
+// Scalar fields are nullable: `null` = "no override, let external sources drive the merged value".
+// Arrays always carry the form value (union-merged downstream).
 type UserInputWriteValues = {
     softwareId: number;
-    name: string;
-    description: LocalizedString;
-    license: string;
+    name: string | LocalizedString | null;
+    description: string | LocalizedString | null;
+    license: string | null;
     image: string | null;
     isLibreSoftware: boolean | null;
     url: string | null;
@@ -97,6 +105,19 @@ type UserInputWriteValues = {
     runtimePlatforms: RuntimePlatform[];
 };
 
+type ExistingUserInputValues = Pick<
+    UserInputWriteValues,
+    | "name"
+    | "description"
+    | "license"
+    | "image"
+    | "isLibreSoftware"
+    | "url"
+    | "codeRepositoryUrl"
+    | "softwareHelp"
+    | "latestVersion"
+>;
+
 // `externalId` is part of the primary key and can't be NULL, so we use `softwareId::text`
 // as a stable sentinel that's unique per software within the `UserInput` source. Refresh/
 // import jobs skip `kind='UserInput'` so this sentinel never gets fed to an external gateway.
@@ -105,8 +126,8 @@ const toUserInputRowValues = (v: UserInputWriteValues) => ({
     sourceSlug: USER_INPUT_SOURCE_SLUG,
     softwareId: v.softwareId,
     authors: JSON.stringify([]),
-    name: JSON.stringify({ fr: v.name }),
-    description: JSON.stringify(v.description),
+    name: v.name === null ? null : JSON.stringify(typeof v.name === "string" ? { fr: v.name } : v.name),
+    description: v.description === null ? null : JSON.stringify(v.description),
     isLibreSoftware: v.isLibreSoftware,
     image: v.image,
     url: v.url,
@@ -122,6 +143,9 @@ const toUserInputRowValues = (v: UserInputWriteValues) => ({
     lastDataFetchAt: new Date()
 });
 
+// On update, an omitted flag means "field not expressed by this client": keep
+// the existing UserInput value. Explicit false writes NULL so mergeExternalData
+// falls through to external sources.
 const buildUserInputWriteValues = (
     softwareId: number,
     software: {
@@ -139,29 +163,43 @@ const buildUserInputWriteValues = (
         applicationCategories: string[];
         operatingSystems: Partial<Record<Os, boolean>>;
         runtimePlatforms: RuntimePlatform[];
-    }
-): UserInputWriteValues => ({
-    softwareId,
-    name: software.name,
-    description: software.description,
-    license: software.license,
-    image: software.image ?? null,
-    isLibreSoftware: software.isLibreSoftware ?? null,
-    url: software.url ?? null,
-    codeRepositoryUrl: software.codeRepositoryUrl ?? null,
-    softwareHelp: software.softwareHelp ?? null,
-    latestVersion: software.latestVersion
-        ? {
-              version: software.latestVersion.version ?? null,
-              releaseDate: software.latestVersion.releaseDate ?? null
-          }
-        : null,
-    keywords: software.keywords,
-    programmingLanguages: software.programmingLanguages ?? null,
-    applicationCategories: software.applicationCategories,
-    operatingSystems: software.operatingSystems,
-    runtimePlatforms: software.runtimePlatforms
-});
+        userInputOverrides: SoftwareUserInputOverrides;
+    },
+    existingUserInput?: ExistingUserInputValues
+): UserInputWriteValues => {
+    const overrides = software.userInputOverrides;
+    const pickScalarField = <T>(field: keyof ExistingUserInputValues, value: T | null | undefined): T | null => {
+        const flag = overrides[field];
+        if (flag === undefined) return (existingUserInput?.[field] as T | null | undefined) ?? null;
+        return flag ? (value ?? null) : null;
+    };
+
+    const latestVersion =
+        software.latestVersion === undefined || software.latestVersion === null
+            ? null
+            : {
+                  version: software.latestVersion.version ?? null,
+                  releaseDate: software.latestVersion.releaseDate ?? null
+              };
+
+    return {
+        softwareId,
+        name: pickScalarField("name", software.name),
+        description: pickScalarField("description", software.description),
+        license: pickScalarField("license", software.license),
+        image: pickScalarField("image", software.image),
+        isLibreSoftware: pickScalarField("isLibreSoftware", software.isLibreSoftware),
+        url: pickScalarField("url", software.url),
+        codeRepositoryUrl: pickScalarField("codeRepositoryUrl", software.codeRepositoryUrl),
+        softwareHelp: pickScalarField("softwareHelp", software.softwareHelp),
+        latestVersion: pickScalarField("latestVersion", latestVersion),
+        keywords: software.keywords,
+        programmingLanguages: software.programmingLanguages ?? null,
+        applicationCategories: software.applicationCategories,
+        operatingSystems: software.operatingSystems,
+        runtimePlatforms: software.runtimePlatforms
+    };
+};
 
 export const createPgSoftwareRepository = (db: Kysely<Database>): SoftwareRepository => {
     return {
@@ -616,7 +654,26 @@ export const createPgSoftwareRepository = (db: Kysely<Database>): SoftwareReposi
                     .where("id", "=", softwareId)
                     .execute();
 
-                const userInputValues = toUserInputRowValues(buildUserInputWriteValues(softwareId, software));
+                const existingUserInput = await trx
+                    .selectFrom("software_external_datas")
+                    .select([
+                        "name",
+                        "description",
+                        "license",
+                        "image",
+                        "isLibreSoftware",
+                        "url",
+                        "codeRepositoryUrl",
+                        "softwareHelp",
+                        "latestVersion"
+                    ])
+                    .where("softwareId", "=", softwareId)
+                    .where("sourceSlug", "=", USER_INPUT_SOURCE_SLUG)
+                    .executeTakeFirst();
+
+                const userInputValues = toUserInputRowValues(
+                    buildUserInputWriteValues(softwareId, software, existingUserInput)
+                );
                 const {
                     externalId: _externalId,
                     sourceSlug: _sourceSlug,

--- a/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.ts
@@ -5,13 +5,7 @@
 import { Kysely, sql } from "kysely";
 import { DatabaseDataType, PopulatedExternalData, SoftwareRepository } from "../../../ports/DbApiV2";
 import type { LocalizedString } from "../../../ports/GetSoftwareExternalData";
-import {
-    SoftwareInList,
-    Software,
-    SoftwareDetail,
-    SoftwareSourceData,
-    SoftwareUserInputOverrides
-} from "../../../usecases/readWriteSillData";
+import { SoftwareInList, Software, SoftwareDetail, SoftwareSourceData } from "../../../usecases/readWriteSillData";
 import type { Os, RuntimePlatform, SimilarSoftware } from "../../../types";
 import { Database, USER_INPUT_SOURCE_SLUG } from "./kysely.database";
 import { stripNullOrUndefinedValues, transformNullToUndefined } from "./kysely.utils";
@@ -89,7 +83,7 @@ const aggregateEnrichedSimilars = (rows: EnrichedSimilarRow[]): Record<number, S
 // Arrays always carry the form value (union-merged downstream).
 type UserInputWriteValues = {
     softwareId: number;
-    name: string | LocalizedString | null;
+    name: string | LocalizedString;
     description: string | LocalizedString | null;
     license: string | null;
     image: string | null;
@@ -105,19 +99,6 @@ type UserInputWriteValues = {
     runtimePlatforms: RuntimePlatform[];
 };
 
-type ExistingUserInputValues = Pick<
-    UserInputWriteValues,
-    | "name"
-    | "description"
-    | "license"
-    | "image"
-    | "isLibreSoftware"
-    | "url"
-    | "codeRepositoryUrl"
-    | "softwareHelp"
-    | "latestVersion"
->;
-
 // `externalId` is part of the primary key and can't be NULL, so we use `softwareId::text`
 // as a stable sentinel that's unique per software within the `UserInput` source. Refresh/
 // import jobs skip `kind='UserInput'` so this sentinel never gets fed to an external gateway.
@@ -126,7 +107,7 @@ const toUserInputRowValues = (v: UserInputWriteValues) => ({
     sourceSlug: USER_INPUT_SOURCE_SLUG,
     softwareId: v.softwareId,
     authors: JSON.stringify([]),
-    name: v.name === null ? null : JSON.stringify(typeof v.name === "string" ? { fr: v.name } : v.name),
+    name: JSON.stringify(typeof v.name === "string" ? { fr: v.name } : v.name),
     description: v.description === null ? null : JSON.stringify(v.description),
     isLibreSoftware: v.isLibreSoftware,
     image: v.image,
@@ -143,56 +124,36 @@ const toUserInputRowValues = (v: UserInputWriteValues) => ({
     lastDataFetchAt: new Date()
 });
 
-// On update, an omitted flag means "field not expressed by this client": keep
-// the existing UserInput value. Explicit false writes NULL so mergeExternalData
-// falls through to external sources.
 const buildUserInputWriteValues = (
     softwareId: number,
     software: {
         name: string;
-        description: LocalizedString;
-        license: string;
-        image?: string | null;
-        isLibreSoftware?: boolean | null;
-        url?: string | null;
-        codeRepositoryUrl?: string | null;
-        softwareHelp?: string | null;
-        latestVersion?: { version?: string | null; releaseDate?: string | null } | null;
+        description: LocalizedString | null;
+        license: string | null;
+        image: string | null;
+        isLibreSoftware: boolean | null;
+        url: string | null;
+        codeRepositoryUrl: string | null;
+        softwareHelp: string | null;
+        latestVersion: { version: string | null; releaseDate: string | null } | null;
         keywords: string[];
         programmingLanguages?: string[] | null;
         applicationCategories: string[];
         operatingSystems: Partial<Record<Os, boolean>>;
         runtimePlatforms: RuntimePlatform[];
-        userInputOverrides: SoftwareUserInputOverrides;
-    },
-    existingUserInput?: ExistingUserInputValues
+    }
 ): UserInputWriteValues => {
-    const overrides = software.userInputOverrides;
-    const pickScalarField = <T>(field: keyof ExistingUserInputValues, value: T | null | undefined): T | null => {
-        const flag = overrides[field];
-        if (flag === undefined) return (existingUserInput?.[field] as T | null | undefined) ?? null;
-        return flag ? (value ?? null) : null;
-    };
-
-    const latestVersion =
-        software.latestVersion === undefined || software.latestVersion === null
-            ? null
-            : {
-                  version: software.latestVersion.version ?? null,
-                  releaseDate: software.latestVersion.releaseDate ?? null
-              };
-
     return {
         softwareId,
-        name: pickScalarField("name", software.name),
-        description: pickScalarField("description", software.description),
-        license: pickScalarField("license", software.license),
-        image: pickScalarField("image", software.image),
-        isLibreSoftware: pickScalarField("isLibreSoftware", software.isLibreSoftware),
-        url: pickScalarField("url", software.url),
-        codeRepositoryUrl: pickScalarField("codeRepositoryUrl", software.codeRepositoryUrl),
-        softwareHelp: pickScalarField("softwareHelp", software.softwareHelp),
-        latestVersion: pickScalarField("latestVersion", latestVersion),
+        name: software.name,
+        description: software.description,
+        license: software.license,
+        image: software.image,
+        isLibreSoftware: software.isLibreSoftware,
+        url: software.url,
+        codeRepositoryUrl: software.codeRepositoryUrl,
+        softwareHelp: software.softwareHelp,
+        latestVersion: software.latestVersion,
         keywords: software.keywords,
         programmingLanguages: software.programmingLanguages ?? null,
         applicationCategories: software.applicationCategories,
@@ -657,26 +618,7 @@ export const createPgSoftwareRepository = (db: Kysely<Database>): SoftwareReposi
                     .where("id", "=", softwareId)
                     .execute();
 
-                const existingUserInput = await trx
-                    .selectFrom("software_external_datas")
-                    .select([
-                        "name",
-                        "description",
-                        "license",
-                        "image",
-                        "isLibreSoftware",
-                        "url",
-                        "codeRepositoryUrl",
-                        "softwareHelp",
-                        "latestVersion"
-                    ])
-                    .where("softwareId", "=", softwareId)
-                    .where("sourceSlug", "=", USER_INPUT_SOURCE_SLUG)
-                    .executeTakeFirst();
-
-                const userInputValues = toUserInputRowValues(
-                    buildUserInputWriteValues(softwareId, software, existingUserInput)
-                );
+                const userInputValues = toUserInputRowValues(buildUserInputWriteValues(softwareId, software));
                 const {
                     externalId: _externalId,
                     sourceSlug: _sourceSlug,

--- a/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgSoftwareRepository.ts
@@ -436,8 +436,10 @@ export const createPgSoftwareRepository = (db: Kysely<Database>): SoftwareReposi
                     dereferencing: deref
                         ? {
                               reason: deref.reason,
+                              // Legacy rows hold epoch ms; normalize to the ISO contract.
                               time: new Date(deref.time).toISOString(),
-                              lastRecommendedVersion: deref.lastRecommendedVersion
+                              lastRecommendedVersion: deref.lastRecommendedVersion,
+                              dereferencedByUserId: deref.dereferencedByUserId
                           }
                         : undefined,
                     applicationCategories: extData?.applicationCategories ?? [],
@@ -569,7 +571,8 @@ export const createPgSoftwareRepository = (db: Kysely<Database>): SoftwareReposi
                     ? {
                           reason: deref.reason,
                           time: new Date(deref.time).toISOString(),
-                          lastRecommendedVersion: deref.lastRecommendedVersion
+                          lastRecommendedVersion: deref.lastRecommendedVersion,
+                          dereferencedByUserId: deref.dereferencedByUserId
                       }
                     : undefined,
                 applicationCategories: extData?.applicationCategories ?? [],
@@ -713,7 +716,7 @@ export const createPgSoftwareRepository = (db: Kysely<Database>): SoftwareReposi
                 .executeTakeFirstOrThrow();
             return +count;
         },
-        unreference: async ({ softwareId, reason, time }) => {
+        unreference: async ({ softwareId, reason, time, dereferencedByUserId }) => {
             const row = await db
                 .selectFrom("softwares")
                 .select("customAttributes")
@@ -728,7 +731,8 @@ export const createPgSoftwareRepository = (db: Kysely<Database>): SoftwareReposi
                     dereferencing: JSON.stringify({
                         reason,
                         time,
-                        lastRecommendedVersion: versionMin
+                        lastRecommendedVersion: versionMin,
+                        dereferencedByUserId
                     })
                 })
                 .where("id", "=", softwareId)

--- a/api/src/core/adapters/dbApi/kysely/kysely.database.ts
+++ b/api/src/core/adapters/dbApi/kysely/kysely.database.ts
@@ -221,8 +221,9 @@ type SoftwaresTable = {
     updateTime: string;
     dereferencing: JSONColumnType<{
         reason?: string;
-        time: number;
+        time: string;
         lastRecommendedVersion?: string;
+        dereferencedByUserId: number;
     }> | null;
     isStillInObservation: boolean;
     customAttributes: JSONColumnType<Record<string, any>> | null;

--- a/api/src/core/adapters/dbApi/kysely/pgDbApi.integration.test.ts
+++ b/api/src/core/adapters/dbApi/kysely/pgDbApi.integration.test.ts
@@ -48,11 +48,11 @@ const softwareFormData: SoftwareFormData = {
         isPresentInSupportContract: true,
         doRespectRgaa: true
     },
-    // Mark description, license and image as explicit user overrides so the
-    // UserInput row shadows the external source for those fields. Other scalars
-    // (url, codeRepositoryUrl, …) stay un-overridden and bubble up from the
-    // external source via mergeExternalData.
-    userInputOverrides: { description: true, license: true, image: true }
+    isLibreSoftware: null,
+    url: null,
+    codeRepositoryUrl: null,
+    softwareHelp: null,
+    latestVersion: null
 };
 
 const softwareExternalData = {
@@ -219,7 +219,7 @@ describe("pgDbApi", () => {
                     "version": "1.0.0"
                 },
                 license: "MIT",
-                image: softwareFormData.image,
+                image: softwareFormData.image ?? undefined,
                 url: softwareExternalData.url,
                 customAttributes: {
                     doRespectRgaa: true,
@@ -244,7 +244,7 @@ describe("pgDbApi", () => {
                         softwareId: undefined
                     }
                 ],
-                description: { fr: softwareFormData.description },
+                description: { fr: softwareFormData.description ?? "" },
                 id: expect.any(Number),
                 name: softwareFormData.name,
                 operatingSystems: {
@@ -311,9 +311,8 @@ describe("pgDbApi", () => {
                     ...softwareFormData,
                     name: "Sparse Software",
                     description: "User-provided description",
-                    license: "Whatever-the-user-typed",
-                    image: "https://user-typed.example.com/logo.png",
-                    userInputOverrides: { description: true }
+                    license: null,
+                    image: null
                 },
                 userId
             });
@@ -335,7 +334,8 @@ describe("pgDbApi", () => {
             expect(userInputRow.license).toBeNull();
             expect(userInputRow.image).toBeNull();
             expect(userInputRow.url).toBeNull();
-            expect(userInputRow.name).toBeNull();
+            // Name is always a catalogue identity field and always written to UserInput.
+            expect(userInputRow.name).toEqual({ fr: "Sparse Software" });
 
             const details = await dbApi.software.getDetails(sparseSoftware!.id);
             expect(details).toBeDefined();

--- a/api/src/core/adapters/dbApi/kysely/pgDbApi.integration.test.ts
+++ b/api/src/core/adapters/dbApi/kysely/pgDbApi.integration.test.ts
@@ -47,7 +47,12 @@ const softwareFormData: SoftwareFormData = {
         isFromFrenchPublicService: false,
         isPresentInSupportContract: true,
         doRespectRgaa: true
-    }
+    },
+    // Mark description, license and image as explicit user overrides so the
+    // UserInput row shadows the external source for those fields. Other scalars
+    // (url, codeRepositoryUrl, …) stay un-overridden and bubble up from the
+    // external source via mergeExternalData.
+    userInputOverrides: { description: true, license: true, image: true }
 };
 
 const softwareExternalData = {
@@ -264,6 +269,85 @@ describe("pgDbApi", () => {
             expect(softwareExternalIds).toHaveLength(2);
             expect(softwareExternalIds).include(externalIdForSource);
             expect(softwareExternalIds).include(similarExternalId);
+        });
+
+        it("UserInput is sparse: scalar fields without an explicit override are NULL and yield to external sources via merge", async () => {
+            // Pre-seed an external source row so the create() flow finds it and binds it.
+            await db
+                .insertInto("software_external_datas")
+                .values({
+                    externalId: externalIdForSource,
+                    sourceSlug: testSource.slug,
+                    softwareId: null,
+                    authors: JSON.stringify([]),
+                    name: JSON.stringify({ en: "External Name" }),
+                    description: JSON.stringify({ en: "External description" }),
+                    license: "GPL-3.0",
+                    image: "https://external.example.com/logo.png",
+                    url: "https://external.example.com",
+                    codeRepositoryUrl: "https://external.example.com/src",
+                    softwareHelp: null,
+                    isLibreSoftware: true,
+                    keywords: JSON.stringify(["external-kw"]),
+                    programmingLanguages: null,
+                    applicationCategories: null,
+                    operatingSystems: null,
+                    runtimePlatforms: null,
+                    latestVersion: null,
+                    referencePublications: null,
+                    identifiers: null,
+                    repoMetadata: null,
+                    providers: null,
+                    dateCreated: null,
+                    lastDataFetchAt: new Date()
+                })
+                .execute();
+
+            const userId = await dbApi.user.add({ ...insertedUser, email: "sparse@example.com" });
+
+            // Submit a form where the user explicitly overrides ONLY description.
+            await makeCreateSofware(dbApi)({
+                formData: {
+                    ...softwareFormData,
+                    name: "Sparse Software",
+                    description: "User-provided description",
+                    license: "Whatever-the-user-typed",
+                    image: "https://user-typed.example.com/logo.png",
+                    userInputOverrides: { description: true }
+                },
+                userId
+            });
+
+            const softwares = await dbApi.software.getFullList();
+            const sparseSoftware = softwares.find(s => s.name === "Sparse Software");
+            expect(sparseSoftware).toBeDefined();
+
+            const userInputRow = await db
+                .selectFrom("software_external_datas")
+                .selectAll()
+                .where("softwareId", "=", sparseSoftware!.id)
+                .where("sourceSlug", "=", "UserInput")
+                .executeTakeFirstOrThrow();
+
+            // description was explicitly overridden — it sits in UserInput row.
+            expect(userInputRow.description).toEqual({ fr: "User-provided description" });
+            // license, image, url were not overridden — UserInput stores NULL so external source drives display.
+            expect(userInputRow.license).toBeNull();
+            expect(userInputRow.image).toBeNull();
+            expect(userInputRow.url).toBeNull();
+            expect(userInputRow.name).toBeNull();
+
+            const details = await dbApi.software.getDetails(sparseSoftware!.id);
+            expect(details).toBeDefined();
+            // User override wins for description.
+            expect(details!.description).toEqual({ fr: "User-provided description" });
+            // External source drives the rest.
+            expect(details!.license).toBe("GPL-3.0");
+            expect(details!.image).toBe("https://external.example.com/logo.png");
+            expect(details!.url).toBe("https://external.example.com");
+            expect(details!.codeRepositoryUrl).toBe("https://external.example.com/src");
+            // softwares.name (denormalized) stays as the form's name regardless of override.
+            expect(details!.name).toBe("Sparse Software");
         });
     });
 

--- a/api/src/core/adapters/hal/getSoftwareForm.ts
+++ b/api/src/core/adapters/hal/getSoftwareForm.ts
@@ -13,20 +13,22 @@ export const halRawSoftwareToSoftwareForm = async (
     halSoftware: HAL.API.Software,
     source: Source
 ): Promise<SoftwareFormData> => {
-    const halAPIGateway = makeHalAPIGateway(source);
-    const codemetaSoftware = await halAPIGateway.software.getCodemetaByUrl(halSoftware.uri_s);
-
     const formData: SoftwareFormData = {
         name: halSoftware.title_s[0],
-        description: halSoftware.abstract_s ? halSoftware.abstract_s[0] : "",
+        description: null,
         ...resolveOsAndPlatforms(halSoftware.softPlatform_s ?? []),
         externalIdForSource: halSoftware.docid,
         sourceSlug: source.slug,
-        license: codemetaSoftware?.license?.[0] ?? "undefined", // TODO 1 case to copyright
+        license: null,
         similarSoftwareExternalDataItems: [],
-        image: undefined,
+        image: null,
         keywords: halSoftware.keyword_s || [],
-        customAttributes: undefined
+        customAttributes: undefined,
+        isLibreSoftware: null,
+        url: null,
+        codeRepositoryUrl: null,
+        softwareHelp: null,
+        latestVersion: null
     };
 
     return formData;

--- a/api/src/core/adapters/wikidata/getSoftwareForm.ts
+++ b/api/src/core/adapters/wikidata/getSoftwareForm.ts
@@ -6,8 +6,6 @@ import { GetSoftwareFormData } from "../../ports/GetSoftwareFormData";
 import { SoftwareFormData } from "../../usecases/readWriteSillData";
 import { makeWikidataAPIAgent } from "./ApiAgent";
 import { WikidataFetchError } from "./ApiAgent/entity";
-import { toCommonsSpecialFilePathUrl } from "./commonsImage";
-import { createGetClaimDataValue } from "./getWikidataSoftware";
 
 export const getWikidataForm: GetSoftwareFormData = async ({
     externalId,
@@ -31,47 +29,26 @@ export const getWikidataForm: GetSoftwareFormData = async ({
             return undefined;
         }
 
-        const { getClaimDataValue } = createGetClaimDataValue({ entity });
-
-        const logoName = getClaimDataValue<"string">("P154")[0];
-
-        const license = await (async () => {
-            const licenseId = getClaimDataValue<"wikibase-entityid">("P275")[0]?.id;
-
-            if (licenseId === undefined) {
-                return undefined;
-            }
-
-            console.info(`I   -> fetching wiki license : ${licenseId}`);
-            const { entity } = await wikidataAgent.fetchEntity(licenseId).catch(() => ({ "entity": undefined }));
-
-            if (entity === undefined) {
-                return undefined;
-            }
-
-            return { "label": entity.aliases.en?.[0]?.value, "id": licenseId };
-        })();
-
         const name =
             entity.labels?.en?.value ?? entity.labels?.fr?.value ?? entity.labels[Object.keys(entity.labels)[0]].value;
-        const description =
-            entity.descriptions?.en?.value ??
-            entity.descriptions?.fr?.value ??
-            entity.descriptions?.[Object.keys(entity.descriptions)[0]]?.value ??
-            "";
 
         return {
             name,
-            description,
+            description: null,
             operatingSystems: { "linux": true, "windows": true, "android": false, "ios": false, "mac": false },
             runtimePlatforms: ["desktop"],
             externalIdForSource: externalId,
             sourceSlug: source.slug,
-            license: license?.label ?? "Copyright",
+            license: null,
             similarSoftwareExternalDataItems: [],
-            image: toCommonsSpecialFilePathUrl(logoName),
+            image: null,
             keywords: [],
-            customAttributes: undefined
+            customAttributes: undefined,
+            isLibreSoftware: null,
+            url: null,
+            codeRepositoryUrl: null,
+            softwareHelp: null,
+            latestVersion: null
         };
     } catch (error) {
         console.error(`Error for ${externalId} : `, error);

--- a/api/src/core/adapters/zenodo/getZenodoSoftwareForm.ts
+++ b/api/src/core/adapters/zenodo/getZenodoSoftwareForm.ts
@@ -28,16 +28,20 @@ export const getZenodoSoftwareFormData: GetSoftwareFormData = memoize(
 const formatRecordToSoftwareFormData = (recordSoftwareItem: Zenodo.Record, source: Source): SoftwareFormData => {
     return {
         name: recordSoftwareItem.title,
-        description: recordSoftwareItem.metadata.description ?? "",
+        description: null,
         operatingSystems: { "linux": false, "windows": false, "android": false, "ios": false, "mac": false },
         runtimePlatforms: ["desktop"], // Probably wrong
         externalIdForSource: recordSoftwareItem.id.toString(),
         sourceSlug: source.slug,
-        license: recordSoftwareItem.metadata.license?.id ?? "Copyright",
+        license: null,
         similarSoftwareExternalDataItems: [],
-        image: undefined,
+        image: null,
         keywords: recordSoftwareItem.metadata.keywords ?? [],
-
-        customAttributes: undefined
+        customAttributes: undefined,
+        isLibreSoftware: null,
+        url: null,
+        codeRepositoryUrl: null,
+        softwareHelp: null,
+        latestVersion: null
     };
 };

--- a/api/src/core/adapters/zenodo/zenodoGateway.test.ts
+++ b/api/src/core/adapters/zenodo/zenodoGateway.test.ts
@@ -111,9 +111,14 @@ const amdSoftwareForm = {
     sourceSlug: "zenodo",
     license: "gpl-3.0",
     similarSoftwareExternalDataItems: [],
-    image: undefined,
+    image: null,
     keywords: ["Geochronology", "Age-depth modeling", "Stratigraphy", "Sedimentology"],
-    customAttributes: undefined
+    customAttributes: undefined,
+    isLibreSoftware: null,
+    url: null,
+    codeRepositoryUrl: null,
+    softwareHelp: null,
+    latestVersion: null
 };
 
 const resultRequest = [

--- a/api/src/core/ports/CompileData.ts
+++ b/api/src/core/ports/CompileData.ts
@@ -23,8 +23,9 @@ export namespace CompiledData {
             dereferencing:
                 | {
                       reason?: string;
-                      time: number;
+                      time: string;
                       lastRecommendedVersion?: string;
+                      dereferencedByUserId: number;
                   }
                 | undefined;
             isStillInObservation: boolean;

--- a/api/src/core/ports/DbApiV2.ts
+++ b/api/src/core/ports/DbApiV2.ts
@@ -86,7 +86,12 @@ export interface SoftwareRepository {
     }) => Promise<{ sourceSlug: string; externalId: string; softwareId: number | undefined }[]>;
     countAddedByUser: (params: { userId: number }) => Promise<number>;
     getAllSillSoftwareExternalIds: (sourceSlug: string) => Promise<string[]>;
-    unreference: (params: { softwareId: number; reason: string; time: number }) => Promise<void>;
+    unreference: (params: {
+        softwareId: number;
+        reason: string;
+        time: string;
+        dereferencedByUserId: number;
+    }) => Promise<void>;
 }
 
 export type PopulatedExternalData = DatabaseDataType.SoftwareExternalDataRow & {

--- a/api/src/core/ports/DbApiV2.ts
+++ b/api/src/core/ports/DbApiV2.ts
@@ -12,7 +12,6 @@ import type {
     Software,
     SoftwareDetail,
     SoftwareInList,
-    SoftwareUserInputOverrides,
     UserWithId
 } from "../usecases/readWriteSillData";
 import type { OmitFromExisting } from "../utils";
@@ -30,22 +29,19 @@ export type SoftwareExtrinsicRow = Pick<
     DatabaseDataType.SoftwareRow,
     "name" | "dereferencing" | "isStillInObservation" | "customAttributes" | "addedByUserId"
 > & {
-    description: LocalizedString;
-    license: string;
-    image: string | undefined;
-    isLibreSoftware: boolean | undefined;
-    url: string | undefined;
-    codeRepositoryUrl: string | undefined;
-    softwareHelp: string | undefined;
-    latestVersion: { version: string | undefined; releaseDate: string | undefined } | undefined;
+    description: LocalizedString | null;
+    license: string | null;
+    image: string | null;
+    isLibreSoftware: boolean | null;
+    url: string | null;
+    codeRepositoryUrl: string | null;
+    softwareHelp: string | null;
+    latestVersion: { version: string | null; releaseDate: string | null } | null;
     keywords: string[];
     programmingLanguages: string[] | undefined;
     applicationCategories: string[];
     operatingSystems: Partial<Record<Os, boolean>>;
     runtimePlatforms: RuntimePlatform[];
-    // `name` always populates `softwares.name` (denormalized for lookup); the
-    // override flag only controls whether the UserInput row carries it too.
-    userInputOverrides: SoftwareUserInputOverrides;
 };
 
 export namespace DatabaseDataType {

--- a/api/src/core/ports/DbApiV2.ts
+++ b/api/src/core/ports/DbApiV2.ts
@@ -12,6 +12,7 @@ import type {
     Software,
     SoftwareDetail,
     SoftwareInList,
+    SoftwareUserInputOverrides,
     UserWithId
 } from "../usecases/readWriteSillData";
 import type { OmitFromExisting } from "../utils";
@@ -42,6 +43,9 @@ export type SoftwareExtrinsicRow = Pick<
     applicationCategories: string[];
     operatingSystems: Partial<Record<Os, boolean>>;
     runtimePlatforms: RuntimePlatform[];
+    // `name` always populates `softwares.name` (denormalized for lookup); the
+    // override flag only controls whether the UserInput row carries it too.
+    userInputOverrides: SoftwareUserInputOverrides;
 };
 
 export namespace DatabaseDataType {

--- a/api/src/core/types/SoftwareTypes.ts
+++ b/api/src/core/types/SoftwareTypes.ts
@@ -25,6 +25,7 @@ export type Dereferencing = {
     reason: string | undefined;
     time: string;
     lastRecommendedVersion: string | undefined;
+    dereferencedByUserId: number;
 };
 
 export type SimilarSoftware = {

--- a/api/src/core/usecases/createSoftware.test.ts
+++ b/api/src/core/usecases/createSoftware.test.ts
@@ -36,7 +36,12 @@ const craSoftwareFormData = {
         doRespectRgaa: true,
         isPresentInSupportContract: true,
         isFromFrenchPublicService: true
-    }
+    },
+    isLibreSoftware: null,
+    url: null,
+    codeRepositoryUrl: null,
+    softwareHelp: null,
+    latestVersion: null
 } satisfies SoftwareFormData;
 
 describe("Create software - Trying all the cases", () => {

--- a/api/src/core/usecases/createSoftware.ts
+++ b/api/src/core/usecases/createSoftware.ts
@@ -36,7 +36,8 @@ export const formDataToSoftwareRow = (softwareForm: SoftwareFormData, userId: nu
                   releaseDate: softwareForm.latestVersion.releaseDate ?? undefined
               }
             : undefined,
-        programmingLanguages: softwareForm.programmingLanguages
+        programmingLanguages: softwareForm.programmingLanguages,
+        userInputOverrides: softwareForm.userInputOverrides ?? {}
     };
 };
 

--- a/api/src/core/usecases/createSoftware.ts
+++ b/api/src/core/usecases/createSoftware.ts
@@ -14,7 +14,7 @@ export type CreateSoftware = (
 export const formDataToSoftwareRow = (softwareForm: SoftwareFormData, userId: number): SoftwareExtrinsicCreation => {
     return {
         name: softwareForm.name,
-        description: { fr: softwareForm.description },
+        description: softwareForm.description === null ? null : { fr: softwareForm.description },
         license: softwareForm.license,
         image: softwareForm.image,
         addedTime: new Date().toISOString(),
@@ -32,12 +32,11 @@ export const formDataToSoftwareRow = (softwareForm: SoftwareFormData, userId: nu
         softwareHelp: softwareForm.softwareHelp,
         latestVersion: softwareForm.latestVersion
             ? {
-                  version: softwareForm.latestVersion.version ?? undefined,
-                  releaseDate: softwareForm.latestVersion.releaseDate ?? undefined
+                  version: softwareForm.latestVersion.version,
+                  releaseDate: softwareForm.latestVersion.releaseDate
               }
-            : undefined,
-        programmingLanguages: softwareForm.programmingLanguages,
-        userInputOverrides: softwareForm.userInputOverrides ?? {}
+            : null,
+        programmingLanguages: softwareForm.programmingLanguages
     };
 };
 

--- a/api/src/core/usecases/readWriteSillData/types.ts
+++ b/api/src/core/usecases/readWriteSillData/types.ts
@@ -121,6 +121,21 @@ export type Instance = {
     isPublic: boolean;
 };
 
+// Arrays (keywords, programmingLanguages, etc.) keep union-merge semantics and
+// aren't part of the override flag — the user can only add to them.
+export type SoftwareUserInputOverridableField =
+    | "name"
+    | "description"
+    | "license"
+    | "image"
+    | "isLibreSoftware"
+    | "url"
+    | "codeRepositoryUrl"
+    | "softwareHelp"
+    | "latestVersion";
+
+export type SoftwareUserInputOverrides = Partial<Record<SoftwareUserInputOverridableField, boolean>>;
+
 export type SoftwareFormData = {
     name: string;
     description: string;
@@ -139,6 +154,9 @@ export type SoftwareFormData = {
     softwareHelp?: string | undefined;
     latestVersion?: { version: string | undefined; releaseDate: string | undefined } | undefined;
     programmingLanguages?: string[] | undefined;
+    // Fields whose flag is absent or false write NULL to the UserInput row.
+    // Default empty = the right behavior for import jobs (no overrides).
+    userInputOverrides?: SoftwareUserInputOverrides;
 };
 
 export type DeclarationFormData = DeclarationFormData.User | DeclarationFormData.Referent;

--- a/api/src/core/usecases/readWriteSillData/types.ts
+++ b/api/src/core/usecases/readWriteSillData/types.ts
@@ -122,42 +122,24 @@ export type Instance = {
     isPublic: boolean;
 };
 
-// Arrays (keywords, programmingLanguages, etc.) keep union-merge semantics and
-// aren't part of the override flag — the user can only add to them.
-export type SoftwareUserInputOverridableField =
-    | "name"
-    | "description"
-    | "license"
-    | "image"
-    | "isLibreSoftware"
-    | "url"
-    | "codeRepositoryUrl"
-    | "softwareHelp"
-    | "latestVersion";
-
-export type SoftwareUserInputOverrides = Partial<Record<SoftwareUserInputOverridableField, boolean>>;
-
 export type SoftwareFormData = {
     name: string;
-    description: string;
+    description: string | null;
     operatingSystems: Partial<Record<Os, boolean>>;
     runtimePlatforms: RuntimePlatform[];
     externalIdForSource: string | undefined;
     sourceSlug: string;
-    license: string;
+    license: string | null;
     similarSoftwareExternalDataItems: SoftwareExternalDataOption[];
-    image: string | undefined;
+    image: string | null;
     keywords: string[];
     customAttributes: CustomAttributes | undefined;
-    isLibreSoftware?: boolean | undefined;
-    url?: string | undefined;
-    codeRepositoryUrl?: string | undefined;
-    softwareHelp?: string | undefined;
-    latestVersion?: { version: string | undefined; releaseDate: string | undefined } | undefined;
+    isLibreSoftware: boolean | null;
+    url: string | null;
+    codeRepositoryUrl: string | null;
+    softwareHelp: string | null;
+    latestVersion: { version: string | null; releaseDate: string | null } | null;
     programmingLanguages?: string[] | undefined;
-    // Fields whose flag is absent or false write NULL to the UserInput row.
-    // Default empty = the right behavior for import jobs (no overrides).
-    userInputOverrides?: SoftwareUserInputOverrides;
 };
 
 export type DeclarationFormData = DeclarationFormData.User | DeclarationFormData.Referent;

--- a/api/src/core/usecases/readWriteSillData/types.ts
+++ b/api/src/core/usecases/readWriteSillData/types.ts
@@ -67,6 +67,7 @@ export type Software = SoftwareData & {
               reason: string | undefined;
               time: string;
               lastRecommendedVersion: string | undefined;
+              dereferencedByUserId: number;
           }
         | undefined;
     customAttributes: CustomAttributes | undefined;

--- a/api/src/core/usecases/refreshExternalData.test.ts
+++ b/api/src/core/usecases/refreshExternalData.test.ts
@@ -44,7 +44,12 @@ const craSoftwareFormData = {
         isPresentInSupportContract: true,
         isFromFrenchPublicService: true,
         doRespectRgaa: true
-    }
+    },
+    isLibreSoftware: null,
+    url: null,
+    codeRepositoryUrl: null,
+    softwareHelp: null,
+    latestVersion: null
 } satisfies SoftwareFormData;
 
 const apacheSoftwareId = 6;

--- a/api/src/core/usecases/updateSoftware.test.ts
+++ b/api/src/core/usecases/updateSoftware.test.ts
@@ -36,7 +36,12 @@ const craSoftwareFormData = {
         isPresentInSupportContract: true,
         isFromFrenchPublicService: true,
         doRespectRgaa: true
-    }
+    },
+    isLibreSoftware: null,
+    url: null,
+    codeRepositoryUrl: null,
+    softwareHelp: null,
+    latestVersion: null
 } satisfies SoftwareFormData;
 
 describe("Create software, than updates it adding a similar software", () => {

--- a/api/src/core/usecases/updateSoftware.ts
+++ b/api/src/core/usecases/updateSoftware.ts
@@ -20,7 +20,7 @@ export const makeUpdateSoftware: (dbApi: DbApiV2) => UpdateSoftware =
         await dbApi.software.update({
             software: {
                 name: formFields.name,
-                description: { fr: formFields.description },
+                description: formFields.description === null ? null : { fr: formFields.description },
                 license: formFields.license,
                 image: formFields.image,
                 dereferencing: undefined,
@@ -37,12 +37,11 @@ export const makeUpdateSoftware: (dbApi: DbApiV2) => UpdateSoftware =
                 softwareHelp: formFields.softwareHelp,
                 latestVersion: formFields.latestVersion
                     ? {
-                          version: formFields.latestVersion.version ?? undefined,
-                          releaseDate: formFields.latestVersion.releaseDate ?? undefined
+                          version: formFields.latestVersion.version,
+                          releaseDate: formFields.latestVersion.releaseDate
                       }
-                    : undefined,
-                programmingLanguages: formFields.programmingLanguages,
-                userInputOverrides: formFields.userInputOverrides ?? {}
+                    : null,
+                programmingLanguages: formFields.programmingLanguages
             },
             softwareId
         });

--- a/api/src/core/usecases/updateSoftware.ts
+++ b/api/src/core/usecases/updateSoftware.ts
@@ -41,7 +41,8 @@ export const makeUpdateSoftware: (dbApi: DbApiV2) => UpdateSoftware =
                           releaseDate: formFields.latestVersion.releaseDate ?? undefined
                       }
                     : undefined,
-                programmingLanguages: formFields.programmingLanguages
+                programmingLanguages: formFields.programmingLanguages,
+                userInputOverrides: formFields.userInputOverrides ?? {}
             },
             softwareId
         });

--- a/api/src/rpc/router.ts
+++ b/api/src/rpc/router.ts
@@ -16,6 +16,7 @@ import {
     DeclarationFormData,
     InstanceFormData,
     SoftwareFormData,
+    SoftwareUserInputOverridableField,
     UserWithId
 } from "../core/usecases/readWriteSillData";
 import type { Os, RuntimePlatform } from "../core/types";
@@ -453,6 +454,27 @@ const zRuntimePlatform = z.enum(["cloud", "mobile", "desktop"]);
     assert<Equals<Got, Expected>>();
 }
 
+const zSoftwareUserInputOverrides = z
+    .object({
+        "name": z.boolean().optional(),
+        "description": z.boolean().optional(),
+        "license": z.boolean().optional(),
+        "image": z.boolean().optional(),
+        "isLibreSoftware": z.boolean().optional(),
+        "url": z.boolean().optional(),
+        "codeRepositoryUrl": z.boolean().optional(),
+        "softwareHelp": z.boolean().optional(),
+        "latestVersion": z.boolean().optional()
+    })
+    .strict()
+    .optional();
+
+{
+    type Got = keyof NonNullable<z.infer<typeof zSoftwareUserInputOverrides>>;
+    type Expected = SoftwareUserInputOverridableField;
+    assert<Equals<Got, Expected>>();
+}
+
 const zSoftwareFormData = (() => {
     const zOut: z.ZodType<OptionalIfCanBeUndefined<SoftwareFormData>> = z.object({
         "operatingSystems": z.record(zOs, z.boolean()),
@@ -465,7 +487,8 @@ const zSoftwareFormData = (() => {
         "similarSoftwareExternalDataItems": z.array(softwareExternalDataOptionSchema),
         "image": z.string().optional(),
         "keywords": z.array(z.string()),
-        "customAttributes": z.record(z.string(), z.any()).optional()
+        "customAttributes": z.record(z.string(), z.any()).optional(),
+        "userInputOverrides": zSoftwareUserInputOverrides
     });
 
     return zOut as z.ZodType<SoftwareFormData>;

--- a/api/src/rpc/router.ts
+++ b/api/src/rpc/router.ts
@@ -420,13 +420,14 @@ export function createRouter(params: {
                     "reason": z.string()
                 })
             )
-            .mutation(async ({ input }) => {
+            .mutation(async ({ ctx: { currentUser }, input }) => {
                 const { softwareId, reason } = input;
 
                 await dbApi.software.unreference({
                     softwareId,
                     reason,
-                    time: Date.now()
+                    time: new Date().toISOString(),
+                    dereferencedByUserId: currentUser.id
                 });
             })
     });

--- a/api/src/rpc/router.ts
+++ b/api/src/rpc/router.ts
@@ -16,7 +16,6 @@ import {
     DeclarationFormData,
     InstanceFormData,
     SoftwareFormData,
-    SoftwareUserInputOverridableField,
     UserWithId
 } from "../core/usecases/readWriteSillData";
 import type { Os, RuntimePlatform } from "../core/types";
@@ -455,27 +454,6 @@ const zRuntimePlatform = z.enum(["cloud", "mobile", "desktop"]);
     assert<Equals<Got, Expected>>();
 }
 
-const zSoftwareUserInputOverrides = z
-    .object({
-        "name": z.boolean().optional(),
-        "description": z.boolean().optional(),
-        "license": z.boolean().optional(),
-        "image": z.boolean().optional(),
-        "isLibreSoftware": z.boolean().optional(),
-        "url": z.boolean().optional(),
-        "codeRepositoryUrl": z.boolean().optional(),
-        "softwareHelp": z.boolean().optional(),
-        "latestVersion": z.boolean().optional()
-    })
-    .strict()
-    .optional();
-
-{
-    type Got = keyof NonNullable<z.infer<typeof zSoftwareUserInputOverrides>>;
-    type Expected = SoftwareUserInputOverridableField;
-    assert<Equals<Got, Expected>>();
-}
-
 const zSoftwareFormData = (() => {
     const zOut: z.ZodType<OptionalIfCanBeUndefined<SoftwareFormData>> = z.object({
         "operatingSystems": z.record(zOs, z.boolean()),
@@ -483,13 +461,23 @@ const zSoftwareFormData = (() => {
         "externalIdForSource": z.string().optional(),
         "sourceSlug": z.string(),
         "name": z.string(),
-        "description": z.string(),
-        "license": z.string(),
+        "description": z.string().nullable(),
+        "license": z.string().nullable(),
         "similarSoftwareExternalDataItems": z.array(softwareExternalDataOptionSchema),
-        "image": z.string().optional(),
+        "image": z.string().nullable(),
         "keywords": z.array(z.string()),
         "customAttributes": z.record(z.string(), z.any()).optional(),
-        "userInputOverrides": zSoftwareUserInputOverrides
+        "isLibreSoftware": z.boolean().nullable(),
+        "url": z.string().nullable(),
+        "codeRepositoryUrl": z.string().nullable(),
+        "softwareHelp": z.string().nullable(),
+        "latestVersion": z
+            .object({
+                "version": z.string().nullable(),
+                "releaseDate": z.string().nullable()
+            })
+            .nullable(),
+        "programmingLanguages": z.array(z.string()).optional()
     });
 
     return zOut as z.ZodType<SoftwareFormData>;

--- a/api/src/rpc/translations/en_default.json
+++ b/api/src/rpc/translations/en_default.json
@@ -124,7 +124,12 @@
         "must be an url": "Must be an URL",
         "keywords": "Keywords",
         "keywords hint": "Keywords for making it pop up in the search results, coma separated",
-        "logo preview alt": "Preview of the logo"
+        "logo preview alt": "Preview of the logo",
+        "source external": "Source: {{sourceName}}",
+        "source user input": "Source: user input",
+        "override field title": "Override the value of {{fieldLabel}}",
+        "cancel override title": "Revert to \"{{value}}\" (from {{sourceName}})",
+        "keywords from source": "Included from {{sourceName}}: {{keywords}}"
     },
     "softwareFormStep4": {
         "similar software": "This software is an alternative to ...",
@@ -413,6 +418,13 @@
         "do you confirm_using": "Do you confirm that you're no longer using",
         "stop being_user": "Stop being a user of {{softwareName}}",
         "stop being_referent": "Stop being a referent of {{softwareName}}"
+    },
+    "overrideWarningModal": {
+        "title": "Override the value of {{fieldLabel}}?",
+        "body": "The value you enter will take precedence over <b>{{sourceName}}</b>. Future automatic refreshes from that source will no longer be reflected on this page.",
+        "editAtSource": "If possible, edit the data directly on <sourceLink>{{sourceName}}</sourceLink> so every consumer benefits from your change.",
+        "cancel": "Cancel",
+        "confirm": "Confirm override"
     },
     "smartLogo": {
         "software logo": "Software logo"

--- a/api/src/rpc/translations/fr_default.json
+++ b/api/src/rpc/translations/fr_default.json
@@ -126,7 +126,12 @@
         "must be an url": "Doit être un URL valide",
         "keywords": "Mot-clés",
         "keywords hint": "mots-clés pour aider à la recherche du logiciel, séparés par des virgules",
-        "logo preview alt": "Aperçu du logo du logiciel"
+        "logo preview alt": "Aperçu du logo du logiciel",
+        "source external": "Source : {{sourceName}}",
+        "source user input": "Source : saisie utilisateur",
+        "override field title": "Surcharger la valeur de {{fieldLabel}}",
+        "cancel override title": "Revenir à « {{value}} » ({{sourceName}})",
+        "keywords from source": "Inclus par {{sourceName}} : {{keywords}}"
     },
     "softwareFormStep4": {
         "similar software": "Ce logiciel est une alternative à ...",
@@ -420,6 +425,13 @@
         "do you confirm_using": "Confirmez vous ne plus utiliser",
         "stop being_user": "Ne plus être utilisateur de {{softwareName}}",
         "stop being_referent": "Ne plus être référent de {{softwareName}}"
+    },
+    "overrideWarningModal": {
+        "title": "Surcharger la valeur de {{fieldLabel}} ?",
+        "body": "La valeur que vous saisissez deviendra prépondérante sur <b>{{sourceName}}</b>. Les mises à jour automatiques depuis cette source ne seront plus reflétées dans la fiche.",
+        "editAtSource": "Si possible, modifiez la donnée directement sur <sourceLink>{{sourceName}}</sourceLink> afin que tous les consommateurs en bénéficient.",
+        "cancel": "Annuler",
+        "confirm": "Confirmer la surcharge"
     },
     "smartLogo": {
         "software logo": "Logo du logiciel"

--- a/api/src/rpc/translations/schema.json
+++ b/api/src/rpc/translations/schema.json
@@ -521,6 +521,26 @@
                 },
                 "logo preview alt": {
                     "type": "string"
+                },
+                "source external": {
+                    "type": "string",
+                    "description": "Hint shown under a field whose value is provided by an external source (state 2)."
+                },
+                "source user input": {
+                    "type": "string",
+                    "description": "Hint shown under a field that the user explicitly overrode (state 3)."
+                },
+                "override field title": {
+                    "type": "string",
+                    "description": "Tooltip on the pencil icon that opens the override-warning modal."
+                },
+                "cancel override title": {
+                    "type": "string",
+                    "description": "Tooltip on the cross icon that reverts an override back to the external source value."
+                },
+                "keywords from source": {
+                    "type": "string",
+                    "description": "Hint listing keywords contributed by an external source (union-merged with the user's own keywords)."
                 }
             },
             "additionalProperties": false,
@@ -539,7 +559,12 @@
                 "must be an url",
                 "keywords",
                 "keywords hint",
-                "logo preview alt"
+                "logo preview alt",
+                "source external",
+                "source user input",
+                "override field title",
+                "cancel override title",
+                "keywords from source"
             ]
         },
         "softwareFormStep4": {
@@ -1686,6 +1711,18 @@
                 "stop being_referent"
             ]
         },
+        "overrideWarningModal": {
+            "type": "object",
+            "properties": {
+                "title": { "type": "string" },
+                "body": { "type": "string" },
+                "editAtSource": { "type": "string" },
+                "cancel": { "type": "string" },
+                "confirm": { "type": "string" }
+            },
+            "additionalProperties": false,
+            "required": ["title", "body", "editAtSource", "cancel", "confirm"]
+        },
         "smartLogo": {
             "type": "object",
             "properties": {
@@ -1771,6 +1808,7 @@
         "authorCard",
         "footer",
         "declarationRemovalModal",
+        "overrideWarningModal",
         "smartLogo",
         "promptForOrganization"
     ]

--- a/api/src/tools/test.helpers.ts
+++ b/api/src/tools/test.helpers.ts
@@ -66,7 +66,12 @@ export const createSoftwareFormData = makeObjectFactory<SoftwareFormData>({
         isPresentInSupportContract: true,
         isFromFrenchPublicService: true,
         doRespectRgaa: true
-    }
+    },
+    isLibreSoftware: null,
+    url: null,
+    codeRepositoryUrl: null,
+    softwareHelp: null,
+    latestVersion: null
 });
 export const createInstanceFormData = makeObjectFactory<InstanceFormData>({
     organization: "Default organization",
@@ -171,8 +176,8 @@ export const resetDB = async (db: Kysely<Database>) => {
                 ...testSource,
                 kind: testSource.kind as ExternalDataOriginKind
             },
-            // The repository writes a UserInput row on every create/update when the flag
-            // is on (the default from ui-config). Seed the source so the FK is satisfied.
+            // The repository writes a UserInput row on every create/update. Seed the
+            // synthetic source so the FK is satisfied.
             {
                 slug: "UserInput",
                 priority: 0,

--- a/helm-charts/catalogi/Chart.yaml
+++ b/helm-charts/catalogi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: catalogi
 description: A Helm chart for deploying the Catalogi open source software catalog.
 type: application
-version: 2.0.45
-appVersion: 1.55.1
+version: 2.0.46
+appVersion: 1.55.2
 dependencies:
   - name: postgresql
     version: '16'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sill",
-  "version": "1.55.1",
+  "version": "1.55.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
     <link rel="shortcut icon" href="/dsfr/favicon/favicon.ico" type="image/x-icon" />
     <link rel="manifest" href="/dsfr/favicon/manifest.webmanifest" crossorigin="use-credentials" />
 
-    <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css?hash=55ac0569" />
+    <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css?hash=fcda3337" />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css" />
 
     %VITE_HEAD%

--- a/web/src/core/usecases/softwareForm/state.ts
+++ b/web/src/core/usecases/softwareForm/state.ts
@@ -45,7 +45,6 @@ export type FormData = {
         image: string | undefined;
         keywords: string[];
         userInputOverrides: {
-            name?: boolean;
             description?: boolean;
             license?: boolean;
             image?: boolean;

--- a/web/src/core/usecases/softwareForm/state.ts
+++ b/web/src/core/usecases/softwareForm/state.ts
@@ -44,6 +44,12 @@ export type FormData = {
         license: string;
         image: string | undefined;
         keywords: string[];
+        userInputOverrides: {
+            name?: boolean;
+            description?: boolean;
+            license?: boolean;
+            image?: boolean;
+        };
     };
     step3: ApiTypes.CustomAttributes | undefined;
     step4: {
@@ -101,7 +107,8 @@ export const { reducer, actions } = createUsecaseActions({
                         description,
                         license,
                         image,
-                        keywords
+                        keywords,
+                        userInputOverrides: {}
                     }
                 },
                 softwareSillId: undefined,

--- a/web/src/core/usecases/softwareForm/thunks.ts
+++ b/web/src/core/usecases/softwareForm/thunks.ts
@@ -113,7 +113,7 @@ export const thunks = {
                                         license: userInputSource?.license ?? "",
                                         name:
                                             userInputSource?.name === undefined
-                                                ? ""
+                                                ? resolveLocalizedString(software.name)
                                                 : resolveLocalizedString(
                                                       userInputSource.name
                                                   ),
@@ -123,7 +123,6 @@ export const thunks = {
                                         // editor explicitly overrode that field, so
                                         // open the form in state 3 for it.
                                         userInputOverrides: {
-                                            name: userInputSource?.name !== undefined,
                                             description:
                                                 userInputSource?.description !==
                                                 undefined,
@@ -215,14 +214,20 @@ export const thunks = {
             assert(step2 !== undefined);
             assert(step3 !== undefined);
 
+            const userInputSource = state.dataBySource.find(
+                source => source.kind === USER_INPUT_SOURCE_SLUG
+            );
+
             const formData: ApiTypes.SoftwareFormData = {
                 operatingSystems: step1.operatingSystems,
                 runtimePlatforms: step1.runtimePlatforms,
                 externalIdForSource: step2.externalId,
                 sourceSlug: mainSource.slug,
                 name: step2.name,
-                description: step2.description,
-                license: step2.license,
+                description: step2.userInputOverrides.description
+                    ? step2.description
+                    : null,
+                license: step2.userInputOverrides.license ? step2.license : null,
                 customAttributes: step3,
                 similarSoftwareExternalDataItems: formDataStep4.similarSoftwares.map(
                     ({ externalId, sourceSlug, name, description, isLibreSoftware }) => ({
@@ -233,9 +238,19 @@ export const thunks = {
                         isLibreSoftware
                     })
                 ),
-                image: step2.image,
+                image: step2.userInputOverrides.image ? (step2.image ?? null) : null,
                 keywords: step2.keywords,
-                userInputOverrides: step2.userInputOverrides
+                isLibreSoftware: userInputSource?.isLibreSoftware ?? null,
+                url: userInputSource?.url ?? null,
+                codeRepositoryUrl: userInputSource?.codeRepositoryUrl ?? null,
+                softwareHelp: userInputSource?.softwareHelp ?? null,
+                latestVersion: userInputSource?.latestVersion
+                    ? {
+                          version: userInputSource.latestVersion.version ?? null,
+                          releaseDate: userInputSource.latestVersion.releaseDate ?? null
+                      }
+                    : null,
+                programmingLanguages: userInputSource?.programmingLanguages
             };
 
             dispatch(actions.submissionStarted());

--- a/web/src/core/usecases/softwareForm/thunks.ts
+++ b/web/src/core/usecases/softwareForm/thunks.ts
@@ -118,7 +118,19 @@ export const thunks = {
                                                       userInputSource.name
                                                   ),
                                         image: userInputSource?.image,
-                                        keywords: userInputSource?.keywords ?? []
+                                        keywords: userInputSource?.keywords ?? [],
+                                        // A non-null UserInput value means a prior
+                                        // editor explicitly overrode that field, so
+                                        // open the form in state 3 for it.
+                                        userInputOverrides: {
+                                            name: userInputSource?.name !== undefined,
+                                            description:
+                                                userInputSource?.description !==
+                                                undefined,
+                                            license:
+                                                userInputSource?.license !== undefined,
+                                            image: userInputSource?.image !== undefined
+                                        }
                                     },
                                     step3: software.customAttributes,
                                     step4: {
@@ -222,7 +234,8 @@ export const thunks = {
                     })
                 ),
                 image: step2.image,
-                keywords: step2.keywords
+                keywords: step2.keywords,
+                userInputOverrides: step2.userInputOverrides
             };
 
             dispatch(actions.submissionStarted());

--- a/web/src/ui/pages/softwareDetails/SourceProvenanceView.tsx
+++ b/web/src/ui/pages/softwareDetails/SourceProvenanceView.tsx
@@ -4,7 +4,6 @@
 
 import { memo, useMemo } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
-import { Button } from "@codegouvfr/react-dsfr/Button";
 import { tss } from "tss-react";
 import { useTranslation } from "react-i18next";
 import { useLang, useResolveLocalizedString, type LocalizedString } from "ui/i18n";
@@ -20,16 +19,10 @@ export type Props = {
     dataBySource: ApiTypes.SoftwareSourceData[];
     /** If set, renders the popover variant scoped to this single field. */
     field?: SourceFieldKey;
-    /** Popover variant only: called when the editor picks a value from a source. */
-    onUseValue?: (params: {
-        sourceSlug: string;
-        field: SourceFieldKey;
-        value: unknown;
-    }) => void;
     className?: string;
 };
 
-const makeRenderValue =
+export const makeRenderValue =
     (resolveLocalizedString: (v: LocalizedString) => string) =>
     (value: unknown): string => {
         if (value === undefined || value === null) return "";
@@ -87,17 +80,14 @@ const FIELD_KEYS = [
     "isLibreSoftware"
 ] as const satisfies readonly SourceFieldKey[];
 
-const isFieldPopulated = (
-    source: ApiTypes.SoftwareSourceData,
-    field: SourceFieldKey
-): boolean => {
-    const v = source[field] as unknown;
-    if (v === undefined || v === null) return false;
-    if (Array.isArray(v)) return v.length > 0;
-    if (typeof v === "object") {
+/** True when `value` is a meaningful contribution (non-empty string/array/object). */
+export const hasMeaningfulValue = (value: unknown): boolean => {
+    if (value === undefined || value === null) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === "object") {
         // Catch empty LocalizedString-like objects ({}, {fr: ""}, {fr: null})
         // and version objects with no usable fields.
-        return Object.values(v as object).some(
+        return Object.values(value as object).some(
             x =>
                 x !== null &&
                 x !== undefined &&
@@ -105,12 +95,17 @@ const isFieldPopulated = (
                 (!Array.isArray(x) || x.length > 0)
         );
     }
-    if (typeof v === "string") return v.length > 0;
+    if (typeof value === "string") return value.length > 0;
     return true;
 };
 
+const isFieldPopulated = (
+    source: ApiTypes.SoftwareSourceData,
+    field: SourceFieldKey
+): boolean => hasMeaningfulValue(source[field]);
+
 export const SourceProvenanceView = memo((props: Props) => {
-    const { dataBySource, field, onUseValue, className } = props;
+    const { dataBySource, field, className } = props;
     const { classes, cx } = useStyles();
     const { t } = useTranslation();
     const { lang } = useLang();
@@ -180,21 +175,6 @@ export const SourceProvenanceView = memo((props: Props) => {
                             <div className={classes.popoverValue}>
                                 {renderValue(source[field])}
                             </div>
-                            {onUseValue && (
-                                <Button
-                                    size="small"
-                                    priority="tertiary"
-                                    onClick={() =>
-                                        onUseValue({
-                                            sourceSlug: source.sourceSlug,
-                                            field,
-                                            value: source[field]
-                                        })
-                                    }
-                                >
-                                    {t("sourceProvenance.useThisValue")}
-                                </Button>
-                            )}
                         </li>
                     ))}
                 </ul>

--- a/web/src/ui/pages/softwareForm/FieldSourcePopover.tsx
+++ b/web/src/ui/pages/softwareForm/FieldSourcePopover.tsx
@@ -16,15 +16,16 @@ import {
 export type Props = {
     dataBySource: ApiTypes.SoftwareSourceData[];
     field: SourceFieldKey;
-    onUseValue?: (value: unknown) => void;
 };
 
 /**
- * A small "i" button that opens a popover showing what every source contributes for
- * a single form field, plus an optional "use this value" handler.
+ * A small "i" button that opens a read-only popover showing what every source
+ * contributes for a single form field. The popover is purely informational —
+ * the editor opts into a UserInput override via the per-field pencil affordance,
+ * not from here.
  */
 export const FieldSourcePopover = memo((props: Props) => {
-    const { dataBySource, field, onUseValue } = props;
+    const { dataBySource, field } = props;
     const { classes } = useStyles();
     const { t } = useTranslation();
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -49,18 +50,7 @@ export const FieldSourcePopover = memo((props: Props) => {
                 anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
                 transformOrigin={{ vertical: "top", horizontal: "left" }}
             >
-                <SourceProvenanceView
-                    dataBySource={dataBySource}
-                    field={field}
-                    onUseValue={
-                        onUseValue
-                            ? ({ value }) => {
-                                  onUseValue(value);
-                                  setAnchorEl(null);
-                              }
-                            : undefined
-                    }
-                />
+                <SourceProvenanceView dataBySource={dataBySource} field={field} />
             </Popover>
         </>
     );

--- a/web/src/ui/pages/softwareForm/OverrideWarningModal.tsx
+++ b/web/src/ui/pages/softwareForm/OverrideWarningModal.tsx
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
+import { Evt } from "evt";
+import { useRerenderOnStateChange } from "evt/hooks";
+import { Trans, useTranslation } from "react-i18next";
+
+const modal = createModal({
+    id: "field-override-warning",
+    isOpenedByDefault: false
+});
+
+type Params = {
+    fieldLabel: string;
+    sourceName: string;
+    sourceUrl: string | undefined;
+    onConfirm: () => void;
+};
+
+const evtParams = Evt.create<Params | undefined>(undefined);
+
+evtParams.toStateless().attach(params => {
+    if (params !== undefined) modal.open();
+});
+
+export function openOverrideWarningModal(params: Params) {
+    evtParams.state = params;
+}
+
+export function OverrideWarningModal() {
+    const { t } = useTranslation();
+
+    useRerenderOnStateChange(evtParams);
+
+    // Drop the closure when the modal is dismissed (cancel/confirm/X/backdrop/Esc)
+    // so onConfirm doesn't pin parent form state until the next override request.
+    useIsModalOpen(modal, {
+        onConceal: () => {
+            evtParams.state = undefined;
+        }
+    });
+
+    const params = evtParams.state;
+
+    return (
+        <modal.Component
+            title={t("overrideWarningModal.title", {
+                fieldLabel: params?.fieldLabel ?? ""
+            })}
+            // type="button" on the inner buttons: the modal is rendered inside
+            // the parent <form> and React bubbles the click through its virtual
+            // tree even though DSFR portals the DOM. Without it, clicks would
+            // submit the form.
+            buttons={[
+                {
+                    doClosesModal: true,
+                    nativeButtonProps: { type: "button" },
+                    children: t("overrideWarningModal.cancel")
+                },
+                {
+                    doClosesModal: true,
+                    nativeButtonProps: { type: "button" },
+                    onClick: () => params?.onConfirm(),
+                    children: t("overrideWarningModal.confirm")
+                }
+            ]}
+        >
+            <p>
+                <Trans
+                    i18nKey="overrideWarningModal.body"
+                    values={{ sourceName: params?.sourceName ?? "" }}
+                    components={{ b: <b /> }}
+                />
+            </p>
+            {params?.sourceUrl !== undefined && (
+                <p>
+                    <Trans
+                        i18nKey="overrideWarningModal.editAtSource"
+                        values={{ sourceName: params.sourceName }}
+                        components={{
+                            sourceLink: (
+                                /* eslint-disable-next-line jsx-a11y/anchor-has-content */
+                                <a
+                                    href={params.sourceUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                />
+                            )
+                        }}
+                    />
+                </p>
+            )}
+        </modal.Component>
+    );
+}

--- a/web/src/ui/pages/softwareForm/Step2.tsx
+++ b/web/src/ui/pages/softwareForm/Step2.tsx
@@ -51,12 +51,7 @@ type ScalarOverridableField = keyof FormData["step2"]["userInputOverrides"];
 
 const fieldRowStyle = { display: "flex", alignItems: "flex-end" } as const;
 
-const SCALAR_FIELDS: ScalarOverridableField[] = [
-    "name",
-    "description",
-    "license",
-    "image"
-];
+const SCALAR_FIELDS: ScalarOverridableField[] = ["description", "license", "image"];
 
 export function SoftwareFormStep2(props: Step2Props) {
     const {
@@ -132,7 +127,24 @@ export function SoftwareFormStep2(props: Step2Props) {
     // identically.
     const [virtualSource, setVirtualSource] = useState<
         ApiTypes.SoftwareSourceData | undefined
-    >(undefined);
+    >(() => {
+        if (isUpdateForm || initialFormData?.externalId === undefined) return undefined;
+
+        return {
+            sourceSlug: "wikidata",
+            priority: 1,
+            kind: "wikidata",
+            sourceUrl: `https://www.wikidata.org/wiki/${initialFormData.externalId}`,
+            externalId: initialFormData.externalId,
+            lastDataFetchAt: undefined,
+            name: initialFormData.name ? { fr: initialFormData.name } : undefined,
+            description: initialFormData.description
+                ? { fr: initialFormData.description }
+                : undefined,
+            license: initialFormData.license,
+            image: initialFormData.image
+        };
+    });
 
     const effectiveDataBySource = useMemo(
         () => (virtualSource ? [virtualSource, ...dataBySource] : dataBySource),
@@ -275,6 +287,8 @@ export function SoftwareFormStep2(props: Step2Props) {
                         document.getElementsByClassName(wikidataInputId);
                     assert(wikidataInputElement !== null);
                     wikidataInputElement.scrollIntoView({ behavior: "smooth" });
+
+                    setValue("name", autofill.name ?? "", { shouldValidate: true });
 
                     setVirtualSource({
                         sourceSlug: "wikidata",
@@ -427,7 +441,6 @@ export function SoftwareFormStep2(props: Step2Props) {
                     };
 
                     const resolved = {
-                        name: resolveField("name", name),
                         description: resolveField("description", description),
                         license: resolveField("license", license),
                         image: resolveField("image", image)
@@ -435,7 +448,7 @@ export function SoftwareFormStep2(props: Step2Props) {
 
                     onSubmit({
                         externalId: wikidataEntry?.externalId,
-                        name: resolved.name.value ?? "",
+                        name,
                         description: resolved.description.value ?? "",
                         license: resolved.license.value ?? "",
                         image:
@@ -448,7 +461,6 @@ export function SoftwareFormStep2(props: Step2Props) {
                             .map(s => s.trim())
                             .filter(Boolean),
                         userInputOverrides: {
-                            name: resolved.name.isOverridden,
                             description: resolved.description.isOverridden,
                             license: resolved.license.isOverridden,
                             image: resolved.image.isOverridden
@@ -562,10 +574,28 @@ export function SoftwareFormStep2(props: Step2Props) {
                     />
                 )}
             </div>
-            {renderField("name", t("softwareFormStep2.software name"), {
-                isRequired: true,
-                errorMessage: t("app.required")
-            })}
+            <div className={css(fieldRowStyle)}>
+                <CircularProgressWrapper
+                    className={css({ flex: 1 })}
+                    isInProgress={isAutocompleteInProgress}
+                    renderChildren={({ style }) => (
+                        <Input
+                            disabled={isAutocompleteInProgress}
+                            style={{
+                                ...style,
+                                marginTop: fr.spacing("4v")
+                            }}
+                            label={t("softwareFormStep2.software name")}
+                            nativeInputProps={{
+                                ...register("name", { required: true })
+                            }}
+                            state={errors.name !== undefined ? "error" : undefined}
+                            stateRelatedMessage={t("app.required")}
+                        />
+                    )}
+                />
+                <FieldSourcePopover dataBySource={effectiveDataBySource} field="name" />
+            </div>
             {renderField("description", t("softwareFormStep2.software feature"), {
                 hintText: t("softwareFormStep2.software feature hint"),
                 isRequired: true,

--- a/web/src/ui/pages/softwareForm/Step2.tsx
+++ b/web/src/ui/pages/softwareForm/Step2.tsx
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
 // SPDX-License-Identifier: MIT
 
-import { useEffect, useState, useId } from "react";
+import { useEffect, useMemo, useState, useId } from "react";
 import { SearchInput } from "ui/shared/SearchInput";
 import { fr } from "@codegouvfr/react-dsfr";
+import { Button } from "@codegouvfr/react-dsfr/Button";
 import { useForm, Controller } from "react-hook-form";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { CircularProgressWrapper } from "ui/shared/CircularProgressWrapper";
@@ -17,8 +18,13 @@ import type { ReturnType } from "tsafe";
 import { useResolveLocalizedString } from "ui/i18n";
 import { Trans, useTranslation } from "react-i18next";
 import { useStyles } from "tss-react";
-import type { ApiTypes } from "api";
+import { USER_INPUT_SOURCE_SLUG, type ApiTypes } from "api";
 import { FieldSourcePopover } from "./FieldSourcePopover";
+import { OverrideWarningModal, openOverrideWarningModal } from "./OverrideWarningModal";
+import {
+    hasMeaningfulValue,
+    makeRenderValue
+} from "ui/pages/softwareDetails/SourceProvenanceView";
 
 export type Step2Props = {
     className?: string;
@@ -41,7 +47,16 @@ export type Step2Props = {
     >;
 };
 
+type ScalarOverridableField = keyof FormData["step2"]["userInputOverrides"];
+
 const fieldRowStyle = { display: "flex", alignItems: "flex-end" } as const;
+
+const SCALAR_FIELDS: ScalarOverridableField[] = [
+    "name",
+    "description",
+    "license",
+    "image"
+];
 
 export function SoftwareFormStep2(props: Step2Props) {
     const {
@@ -57,21 +72,10 @@ export function SoftwareFormStep2(props: Step2Props) {
 
     const { t } = useTranslation();
     const { resolveLocalizedString } = useResolveLocalizedString();
-
-    const resolveToString = (value: unknown): string => {
-        if (typeof value === "string") return value;
-        if (value && typeof value === "object" && !Array.isArray(value)) {
-            const entries = Object.entries(value).filter(
-                ([, v]) => typeof v === "string" && v.length > 0
-            );
-            if (entries.length > 0) {
-                return resolveLocalizedString(
-                    Object.fromEntries(entries) as Record<string, string>
-                );
-            }
-        }
-        return "";
-    };
+    const renderValue = useMemo(
+        () => makeRenderValue(resolveLocalizedString),
+        [resolveLocalizedString]
+    );
 
     const {
         handleSubmit,
@@ -95,7 +99,12 @@ export function SoftwareFormStep2(props: Step2Props) {
                 return undefined;
             }
 
-            const { externalId, keywords, ...rest } = initialFormData ?? {};
+            const {
+                externalId,
+                keywords,
+                userInputOverrides: _o,
+                ...rest
+            } = initialFormData ?? {};
 
             return {
                 ...rest,
@@ -111,6 +120,110 @@ export function SoftwareFormStep2(props: Step2Props) {
             };
         })()
     });
+
+    const [userInputOverrides, setUserInputOverrides] = useState<
+        FormData["step2"]["userInputOverrides"]
+    >(() => initialFormData?.userInputOverrides ?? {});
+
+    // dataBySource is empty in create mode until the software is persisted.
+    // Without a stand-in, every field would land in state 1 and any user
+    // interaction would silently force an override. virtualSource feeds the
+    // same code path as a real persisted source so create and update behave
+    // identically.
+    const [virtualSource, setVirtualSource] = useState<
+        ApiTypes.SoftwareSourceData | undefined
+    >(undefined);
+
+    const effectiveDataBySource = useMemo(
+        () => (virtualSource ? [virtualSource, ...dataBySource] : dataBySource),
+        [virtualSource, dataBySource]
+    );
+
+    type FieldUiState = {
+        externalSource: ApiTypes.SoftwareSourceData | undefined;
+        hasExternal: boolean;
+        isOverridden: boolean;
+        isEditable: boolean;
+        showPencil: boolean;
+        showCross: boolean;
+        externalValue: string;
+        hintText: string | undefined;
+    };
+
+    const fieldUiStates = useMemo(() => {
+        const out = {} as Record<ScalarOverridableField, FieldUiState>;
+        for (const field of SCALAR_FIELDS) {
+            // effectiveDataBySource is ordered highest-precedence first; first
+            // non-UserInput source with a value wins.
+            const externalSource = effectiveDataBySource.find(
+                s =>
+                    s.kind !== USER_INPUT_SOURCE_SLUG &&
+                    hasMeaningfulValue((s as Record<string, unknown>)[field])
+            );
+            const hasExternal = externalSource !== undefined;
+            const isOverridden = userInputOverrides[field] === true;
+            const externalValue = externalSource
+                ? renderValue((externalSource as Record<string, unknown>)[field])
+                : "";
+            out[field] = {
+                externalSource,
+                hasExternal,
+                isOverridden,
+                isEditable: !hasExternal || isOverridden,
+                showPencil: hasExternal && !isOverridden,
+                showCross: hasExternal && isOverridden,
+                externalValue,
+                hintText: !hasExternal
+                    ? undefined
+                    : isOverridden
+                      ? t("softwareFormStep2.source user input")
+                      : t("softwareFormStep2.source external", {
+                            sourceName: externalSource!.sourceSlug
+                        })
+            };
+        }
+        return out;
+    }, [effectiveDataBySource, userInputOverrides, renderValue, t]);
+
+    const requestOverride = (field: ScalarOverridableField, fieldLabel: string) => {
+        const ui = fieldUiStates[field];
+        if (!ui.hasExternal) return;
+        openOverrideWarningModal({
+            fieldLabel,
+            sourceName: ui.externalSource!.sourceSlug,
+            sourceUrl: ui.externalSource!.sourceUrl,
+            onConfirm: () => {
+                setUserInputOverrides(prev => ({ ...prev, [field]: true }));
+                setValue(field, ui.externalValue, { shouldValidate: true });
+            }
+        });
+    };
+
+    // External-source keyword contributions surfaced under the keywords input.
+    // Read-only — the union merge cannot un-include external keywords (v1 limitation).
+    const keywordContributions = useMemo(
+        () =>
+            effectiveDataBySource.reduce<
+                { source: ApiTypes.SoftwareSourceData; keywords: string[] }[]
+            >((acc, source) => {
+                if (source.kind === USER_INPUT_SOURCE_SLUG) return acc;
+                const keywords = Array.isArray(source.keywords) ? source.keywords : [];
+                if (keywords.length > 0) acc.push({ source, keywords });
+                return acc;
+            }, []),
+        [effectiveDataBySource]
+    );
+
+    const cancelOverride = (field: ScalarOverridableField) => {
+        setUserInputOverrides(prev => {
+            // Absence and `false` both mean "no UserInput override"; keep the
+            // payload compact while letting submit recompute explicit false flags.
+            const next = { ...prev };
+            delete next[field];
+            return next;
+        });
+        setValue(field, "", { shouldValidate: true });
+    };
 
     const [submitButtonElement, setSubmitButtonElement] =
         useState<HTMLButtonElement | null>(null);
@@ -131,10 +244,13 @@ export function SoftwareFormStep2(props: Step2Props) {
     const { isAutocompleteInProgress } = (function useClosure() {
         const [isAutocompleteInProgress, setIsAutocompleteInProgress] = useState(false);
 
-        const wikiDataEntry = watch("wikidataEntry");
+        const wikidataExternalId = watch("wikidataEntry")?.externalId;
 
         useEffect(() => {
-            if (wikiDataEntry === undefined || isUpdateForm) {
+            if (isUpdateForm) return;
+            if (wikidataExternalId === undefined) {
+                setIsAutocompleteInProgress(false);
+                setVirtualSource(undefined);
                 return;
             }
 
@@ -142,65 +258,203 @@ export function SoftwareFormStep2(props: Step2Props) {
 
             (async () => {
                 setIsAutocompleteInProgress(true);
+                setUserInputOverrides({});
+                for (const field of SCALAR_FIELDS) {
+                    setValue(field, "", { shouldValidate: true });
+                }
+                setVirtualSource(undefined);
 
-                const { name, description, license, image } =
-                    await getAutofillDataFromWikidata({
-                        externalId: wikiDataEntry.externalId
+                try {
+                    const autofill = await getAutofillDataFromWikidata({
+                        externalId: wikidataExternalId
                     });
 
-                if (!isActive) {
-                    return;
-                }
+                    if (!isActive) return;
 
-                {
                     const [wikidataInputElement] =
                         document.getElementsByClassName(wikidataInputId);
-
                     assert(wikidataInputElement !== null);
-
                     wikidataInputElement.scrollIntoView({ behavior: "smooth" });
-                }
 
-                if (description !== undefined) {
-                    setValue("description", description);
+                    setVirtualSource({
+                        sourceSlug: "wikidata",
+                        priority: 1,
+                        kind: "wikidata",
+                        sourceUrl: `https://www.wikidata.org/wiki/${wikidataExternalId}`,
+                        externalId: wikidataExternalId,
+                        lastDataFetchAt: undefined,
+                        name: autofill.name ? { fr: autofill.name } : undefined,
+                        description: autofill.description
+                            ? { fr: autofill.description }
+                            : undefined,
+                        license: autofill.license,
+                        image: autofill.image
+                    });
+                } catch (error) {
+                    if (isActive) {
+                        console.error("Failed to autofill software form from Wikidata", {
+                            wikidataExternalId,
+                            error
+                        });
+                    }
+                } finally {
+                    if (isActive) setIsAutocompleteInProgress(false);
                 }
-
-                if (license !== undefined) {
-                    setValue("license", license);
-                }
-
-                if (name !== undefined) {
-                    setValue("name", name);
-                }
-
-                if (image !== undefined) {
-                    setValue("image", image);
-                }
-
-                setIsAutocompleteInProgress(false);
             })();
 
             return () => {
                 isActive = false;
             };
-        }, [wikiDataEntry]);
+        }, [wikidataExternalId, isUpdateForm, setValue]);
 
         return { isAutocompleteInProgress };
     })();
 
     const { css } = useStyles();
 
+    const renderToggleButton = (
+        action: "override" | "cancel",
+        field: ScalarOverridableField,
+        fieldLabel: string,
+        ui: FieldUiState
+    ) => {
+        const label =
+            action === "override"
+                ? t("softwareFormStep2.override field title", { fieldLabel })
+                : t("softwareFormStep2.cancel override title", {
+                      value: ui.externalValue,
+                      sourceName: ui.externalSource!.sourceSlug
+                  });
+        return (
+            <Button
+                type="button"
+                iconId={
+                    action === "override" ? "fr-icon-edit-line" : "fr-icon-close-line"
+                }
+                priority="tertiary no outline"
+                title={label}
+                onClick={() =>
+                    action === "override"
+                        ? requestOverride(field, fieldLabel)
+                        : cancelOverride(field)
+                }
+            >
+                <span className="fr-sr-only">{label}</span>
+            </Button>
+        );
+    };
+
+    const renderField = (
+        field: ScalarOverridableField,
+        fieldLabel: string,
+        opts: {
+            hintText?: string;
+            isRequired: boolean;
+            pattern?: RegExp;
+            errorMessage?: string;
+        }
+    ) => {
+        const ui = fieldUiStates[field];
+        const showError = opts.isRequired && ui.isEditable && errors[field] !== undefined;
+
+        return (
+            <div className={css(fieldRowStyle)}>
+                <CircularProgressWrapper
+                    className={css({ flex: 1 })}
+                    isInProgress={isAutocompleteInProgress}
+                    renderChildren={({ style }) => (
+                        <Input
+                            disabled={isAutocompleteInProgress || !ui.isEditable}
+                            style={{ ...style, marginTop: fr.spacing("4v") }}
+                            label={fieldLabel}
+                            hintText={ui.hintText ?? opts.hintText}
+                            nativeInputProps={{
+                                // Skip `required` when an external source already
+                                // provides a value: an empty input then means
+                                // "fall back to the source", not an error.
+                                ...register(field, {
+                                    required:
+                                        opts.isRequired &&
+                                        ui.isEditable &&
+                                        !ui.hasExternal,
+                                    pattern: opts.pattern
+                                }),
+                                value: ui.isEditable ? watch(field) : ui.externalValue
+                            }}
+                            state={showError ? "error" : undefined}
+                            stateRelatedMessage={
+                                showError ? opts.errorMessage : undefined
+                            }
+                        />
+                    )}
+                />
+                {ui.showPencil && renderToggleButton("override", field, fieldLabel, ui)}
+                {ui.showCross && renderToggleButton("cancel", field, fieldLabel, ui)}
+                <FieldSourcePopover dataBySource={effectiveDataBySource} field={field} />
+            </div>
+        );
+    };
+
+    const imagePreviewUrl = fieldUiStates.image.isEditable
+        ? watch("image")
+        : fieldUiStates.image.externalValue;
+
     return (
         <form
             className={className}
             onSubmit={handleSubmit(
-                ({ wikidataEntry, image, keywordsInputValue, ...rest }) =>
+                ({
+                    wikidataEntry,
+                    image,
+                    keywordsInputValue,
+                    name,
+                    description,
+                    license
+                }) => {
+                    // Empty value + external source available = implicit fallback
+                    // to state 2 (drop the override). The cross button is the
+                    // explicit affordance; emptying the input is a shortcut.
+                    const resolveField = (
+                        field: ScalarOverridableField,
+                        value: string | undefined
+                    ): { value: string | undefined; isOverridden: boolean } => {
+                        const ui = fieldUiStates[field];
+                        const isEmpty = value === undefined || value === "";
+                        if (ui.hasExternal && (!ui.isOverridden || isEmpty)) {
+                            return { value: ui.externalValue, isOverridden: false };
+                        }
+                        return { value, isOverridden: ui.isOverridden || !isEmpty };
+                    };
+
+                    const resolved = {
+                        name: resolveField("name", name),
+                        description: resolveField("description", description),
+                        license: resolveField("license", license),
+                        image: resolveField("image", image)
+                    };
+
                     onSubmit({
-                        ...rest,
-                        image: image === "" ? undefined : image,
-                        keywords: keywordsInputValue.split(",").map(s => s.trim()),
-                        externalId: wikidataEntry?.externalId
-                    })
+                        externalId: wikidataEntry?.externalId,
+                        name: resolved.name.value ?? "",
+                        description: resolved.description.value ?? "",
+                        license: resolved.license.value ?? "",
+                        image:
+                            resolved.image.value === undefined ||
+                            resolved.image.value === ""
+                                ? undefined
+                                : resolved.image.value,
+                        keywords: keywordsInputValue
+                            .split(",")
+                            .map(s => s.trim())
+                            .filter(Boolean),
+                        userInputOverrides: {
+                            name: resolved.name.isOverridden,
+                            description: resolved.description.isOverridden,
+                            license: resolved.license.isOverridden,
+                            image: resolved.image.isOverridden
+                        }
+                    });
+                }
             )}
         >
             <Controller
@@ -287,31 +541,15 @@ export function SoftwareFormStep2(props: Step2Props) {
                     alignItems: "end"
                 }}
             >
-                <CircularProgressWrapper
-                    className={css({ flex: 1 })}
-                    isInProgress={isAutocompleteInProgress}
-                    renderChildren={({ style }) => (
-                        <Input
-                            disabled={isAutocompleteInProgress}
-                            style={{
-                                ...style,
-                                marginTop: fr.spacing("4v")
-                            }}
-                            label={t("softwareFormStep2.logo url")}
-                            hintText={t("softwareFormStep2.logo url hint")}
-                            nativeInputProps={{
-                                ...register("image", {
-                                    pattern: /^(?:https:)?\/\//
-                                })
-                            }}
-                            state={errors.image !== undefined ? "error" : undefined}
-                            stateRelatedMessage={t("softwareFormStep2.must be an url")}
-                        />
-                    )}
-                />
-                {watch("image") && (
+                {renderField("image", t("softwareFormStep2.logo url"), {
+                    hintText: t("softwareFormStep2.logo url hint"),
+                    isRequired: false,
+                    pattern: /^(?:https:)?\/\//,
+                    errorMessage: t("softwareFormStep2.must be an url")
+                })}
+                {imagePreviewUrl && (
                     <img
-                        src={watch("image")}
+                        src={imagePreviewUrl}
                         alt={t("softwareFormStep2.logo preview alt")}
                         style={{
                             marginLeft: fr.spacing("4v"),
@@ -324,86 +562,20 @@ export function SoftwareFormStep2(props: Step2Props) {
                     />
                 )}
             </div>
-            <div className={css(fieldRowStyle)}>
-                <CircularProgressWrapper
-                    className={css({ flex: 1 })}
-                    isInProgress={isAutocompleteInProgress}
-                    renderChildren={({ style }) => (
-                        <Input
-                            disabled={isAutocompleteInProgress}
-                            style={{
-                                ...style,
-                                marginTop: fr.spacing("4v")
-                            }}
-                            label={t("softwareFormStep2.software name")}
-                            nativeInputProps={{
-                                ...register("name", { required: true })
-                            }}
-                            state={errors.name !== undefined ? "error" : undefined}
-                            stateRelatedMessage={t("app.required")}
-                        />
-                    )}
-                />
-                <FieldSourcePopover
-                    dataBySource={dataBySource}
-                    field="name"
-                    onUseValue={value => setValue("name", resolveToString(value))}
-                />
-            </div>
-            <div className={css(fieldRowStyle)}>
-                <CircularProgressWrapper
-                    className={css({ flex: 1 })}
-                    isInProgress={isAutocompleteInProgress}
-                    renderChildren={({ style }) => (
-                        <Input
-                            disabled={isAutocompleteInProgress}
-                            style={{
-                                ...style,
-                                marginTop: fr.spacing("4v")
-                            }}
-                            label={t("softwareFormStep2.software feature")}
-                            hintText={t("softwareFormStep2.software feature hint")}
-                            nativeInputProps={{
-                                ...register("description", { required: true })
-                            }}
-                            state={errors.description !== undefined ? "error" : undefined}
-                            stateRelatedMessage={t("app.required")}
-                        />
-                    )}
-                />
-                <FieldSourcePopover
-                    dataBySource={dataBySource}
-                    field="description"
-                    onUseValue={value => setValue("description", resolveToString(value))}
-                />
-            </div>
-            <div className={css(fieldRowStyle)}>
-                <CircularProgressWrapper
-                    className={css({ flex: 1 })}
-                    isInProgress={isAutocompleteInProgress}
-                    renderChildren={({ style }) => (
-                        <Input
-                            disabled={isAutocompleteInProgress}
-                            style={{
-                                ...style,
-                                marginTop: fr.spacing("4v")
-                            }}
-                            label={t("softwareFormStep2.license")}
-                            hintText={t("softwareFormStep2.license hint")}
-                            nativeInputProps={{
-                                ...register("license", { required: true })
-                            }}
-                            state={errors.license !== undefined ? "error" : undefined}
-                            stateRelatedMessage={t("app.required")}
-                        />
-                    )}
-                />
-                <FieldSourcePopover
-                    dataBySource={dataBySource}
-                    field="license"
-                    onUseValue={value => setValue("license", resolveToString(value))}
-                />
-            </div>
+            {renderField("name", t("softwareFormStep2.software name"), {
+                isRequired: true,
+                errorMessage: t("app.required")
+            })}
+            {renderField("description", t("softwareFormStep2.software feature"), {
+                hintText: t("softwareFormStep2.software feature hint"),
+                isRequired: true,
+                errorMessage: t("app.required")
+            })}
+            {renderField("license", t("softwareFormStep2.license"), {
+                hintText: t("softwareFormStep2.license hint"),
+                isRequired: true,
+                errorMessage: t("app.required")
+            })}
 
             <Input
                 disabled={isAutocompleteInProgress}
@@ -416,11 +588,32 @@ export function SoftwareFormStep2(props: Step2Props) {
                     ...register("keywordsInputValue")
                 }}
             />
+            {keywordContributions.length > 0 && (
+                <ul
+                    className={fr.cx("fr-text--xs")}
+                    style={{
+                        marginTop: fr.spacing("1v"),
+                        color: fr.colors.decisions.text.mention.grey.default,
+                        listStyle: "none",
+                        paddingLeft: 0
+                    }}
+                >
+                    {keywordContributions.map(({ source, keywords }) => (
+                        <li key={source.sourceSlug}>
+                            {t("softwareFormStep2.keywords from source", {
+                                sourceName: source.sourceSlug,
+                                keywords: keywords.join(", ")
+                            })}
+                        </li>
+                    ))}
+                </ul>
+            )}
             <button
                 style={{ display: "none" }}
                 ref={setSubmitButtonElement}
                 type="submit"
             />
+            <OverrideWarningModal />
         </form>
     );
 }


### PR DESCRIPTION
## Résumé

- stabilise les overrides scalaires UserInput dans le formulaire logiciel, notamment au changement de QID en création
- corrige la preview image et les popovers pour utiliser la valeur/source effective
- préserve côté API les overrides UserInput non pilotés par le web lors d’un update
- ajoute les tests de transition true/false, de préservation hors UI et de merge/dedup des keywords

## Cause

Le formulaire web ne sait exprimer que `name`, `description`, `license` et `image`, alors que l’API expose aussi `isLibreSoftware`, `url`, `codeRepositoryUrl`, `softwareHelp` et `latestVersion`. Un update web pouvait donc remettre à `NULL` des overrides existants sur ces champs hors UI.

## Validation

- `pnpm --filter api typecheck`
- `pnpm --filter web typecheck`
- `pnpm --filter api exec vitest --watch=false --no-file-parallelism src/core/adapters/dbApi/kysely/createPgSoftwareRepository.test.ts src/core/adapters/dbApi/kysely/mergeExternalData.test.ts src/core/adapters/dbApi/kysely/pgDbApi.integration.test.ts`
- `git diff --check`
- `pnpm --filter web lint`
- `pnpm --filter web build`
- pre-push: `turbo format:check lint typecheck`

## Dette connue

Deux éditeurs peuvent toujours s’écraser sans avertissement. Une vraie correction demande un mécanisme de versioning ou un `updatedAt` attendu à la soumission.
