### PR TITLE
feat: admin role + /admin page to manage custom attributes

### DIFF
--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -59,7 +59,8 @@ const seed = async () => {
         about: "This is a fake user for seeding purposes.",
         isPublic: true,
         organization: "Seed Organization",
-        sub: null
+        sub: null,
+        role: "user"
     };
 
     const testUser: OmitFromExisting<DbUser, "id"> = {
@@ -67,7 +68,8 @@ const seed = async () => {
         about: undefined,
         isPublic: false,
         organization: "DINUM",
-        sub: null
+        sub: null,
+        role: "admin"
     };
 
     const UCCreateSofware = makeCreateSofware(dbApi);

--- a/api/src/core/adapters/dbApi/kysely/createPgAttributeDefinitionRepository.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgAttributeDefinitionRepository.ts
@@ -31,6 +31,7 @@ export const createPgAttributeDefinitionRepository = (db: Kysely<Database>): Att
                 label: JSON.stringify(def.label),
                 description: def.description ? JSON.stringify(def.description) : null,
                 displayInForm: def.displayInForm,
+                editableByAdminOnly: def.editableByAdminOnly,
                 displayInDetails: def.displayInDetails,
                 displayInCardIcon: def.displayInCardIcon ?? null,
                 enableFiltering: def.enableFiltering,
@@ -48,6 +49,7 @@ export const createPgAttributeDefinitionRepository = (db: Kysely<Database>): Att
         if (patch.description !== undefined)
             set.description = patch.description ? JSON.stringify(patch.description) : null;
         if (patch.displayInForm !== undefined) set.displayInForm = patch.displayInForm;
+        if (patch.editableByAdminOnly !== undefined) set.editableByAdminOnly = patch.editableByAdminOnly;
         if (patch.displayInDetails !== undefined) set.displayInDetails = patch.displayInDetails;
         if (patch.displayInCardIcon !== undefined) set.displayInCardIcon = patch.displayInCardIcon ?? null;
         if (patch.enableFiltering !== undefined) set.enableFiltering = patch.enableFiltering;

--- a/api/src/core/adapters/dbApi/kysely/createPgAttributeDefinitionRepository.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgAttributeDefinitionRepository.ts
@@ -21,5 +21,38 @@ export const createPgAttributeDefinitionRepository = (db: Kysely<Database>): Att
             .selectAll()
             .where("name", "=", name)
             .executeTakeFirst()
-            .then(row => (row ? stripNullOrUndefinedValues(row) : undefined))
+            .then(row => (row ? stripNullOrUndefinedValues(row) : undefined)),
+    add: async def => {
+        await db
+            .insertInto("software_attribute_definitions")
+            .values({
+                name: def.name,
+                kind: def.kind,
+                label: JSON.stringify(def.label),
+                description: def.description ? JSON.stringify(def.description) : null,
+                displayInForm: def.displayInForm,
+                displayInDetails: def.displayInDetails,
+                displayInCardIcon: def.displayInCardIcon ?? null,
+                enableFiltering: def.enableFiltering,
+                required: def.required,
+                displayOrder: def.displayOrder,
+                createdAt: def.createdAt,
+                updatedAt: def.updatedAt
+            })
+            .execute();
+    },
+    update: async (name, patch) => {
+        if (Object.keys(patch).length === 0) return;
+        const set: Record<string, unknown> = { updatedAt: new Date() };
+        if (patch.label !== undefined) set.label = JSON.stringify(patch.label);
+        if (patch.description !== undefined)
+            set.description = patch.description ? JSON.stringify(patch.description) : null;
+        if (patch.displayInForm !== undefined) set.displayInForm = patch.displayInForm;
+        if (patch.displayInDetails !== undefined) set.displayInDetails = patch.displayInDetails;
+        if (patch.displayInCardIcon !== undefined) set.displayInCardIcon = patch.displayInCardIcon ?? null;
+        if (patch.enableFiltering !== undefined) set.enableFiltering = patch.enableFiltering;
+        if (patch.required !== undefined) set.required = patch.required;
+        if (patch.displayOrder !== undefined) set.displayOrder = patch.displayOrder;
+        await db.updateTable("software_attribute_definitions").set(set).where("name", "=", name).execute();
+    }
 });

--- a/api/src/core/adapters/dbApi/kysely/createPgUserRepository.ts
+++ b/api/src/core/adapters/dbApi/kysely/createPgUserRepository.ts
@@ -72,6 +72,7 @@ export const createPgUserRepository = (db: Kysely<Database>): UserRepository => 
                 "users.about",
                 "users.organization",
                 "users.sub",
+                "users.role",
                 ({ ref, fn }) =>
                     fn
                         .coalesce(
@@ -157,6 +158,7 @@ const makeGetUserBuilder = (db: Kysely<Database>) =>
             "users.about",
             "users.organization",
             "users.sub",
+            "users.role",
             ({ ref, fn }) =>
                 fn
                     .coalesce(

--- a/api/src/core/adapters/dbApi/kysely/kysely.database.ts
+++ b/api/src/core/adapters/dbApi/kysely/kysely.database.ts
@@ -94,9 +94,12 @@ type UsersTable = {
     about: string | null;
     isPublic: boolean;
     sub: string | null;
+    role: Generated<UserRole>;
     createdAt: Date | null;
     updatedAt: Date | null;
 };
+
+export type UserRole = "user" | "admin";
 
 type Os = "windows" | "linux" | "mac" | "android" | "ios";
 

--- a/api/src/core/adapters/dbApi/kysely/kysely.database.ts
+++ b/api/src/core/adapters/dbApi/kysely/kysely.database.ts
@@ -179,6 +179,7 @@ type SoftwareAttributeDefinitionsTable = {
     label: JSONColumnType<LocalizedString>;
     description: JSONColumnType<LocalizedString> | null;
     displayInForm: boolean;
+    editableByAdminOnly: boolean;
     displayInDetails: boolean;
     displayInCardIcon: "computer" | "france" | "question" | "thumbs-up" | "chat" | "star" | null;
     enableFiltering: boolean;

--- a/api/src/core/adapters/dbApi/kysely/migrations/1778168171859_add-user-role.ts
+++ b/api/src/core/adapters/dbApi/kysely/migrations/1778168171859_add-user-role.ts
@@ -1,0 +1,15 @@
+import { Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .alterTable("users")
+        .addColumn("role", "text", col => col.notNull().defaultTo("user"))
+        .execute();
+
+    await sql`ALTER TABLE users ADD CONSTRAINT users_role_check CHECK (role IN ('user', 'admin'))`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await sql`ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check`.execute(db);
+    await db.schema.alterTable("users").dropColumn("role").execute();
+}

--- a/api/src/core/adapters/dbApi/kysely/migrations/1778676305325_add-editable-by-admin-only-to-custom-attributes.ts
+++ b/api/src/core/adapters/dbApi/kysely/migrations/1778676305325_add-editable-by-admin-only-to-custom-attributes.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import { type Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .alterTable("software_attribute_definitions")
+        .addColumn("editableByAdminOnly", "boolean", col => col.notNull().defaultTo(false))
+        .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await db.schema.alterTable("software_attribute_definitions").dropColumn("editableByAdminOnly").execute();
+}

--- a/api/src/core/adapters/dbApi/kysely/pgDbApi.integration.test.ts
+++ b/api/src/core/adapters/dbApi/kysely/pgDbApi.integration.test.ts
@@ -120,7 +120,8 @@ const insertedUser = {
     organization: "test-organization",
     isPublic: true,
     about: "test about",
-    sub: null
+    sub: null,
+    role: "user" as const
 };
 
 const db = new Kysely<Database>({ dialect: createPgDialect(testPgUrl) });
@@ -439,7 +440,8 @@ describe("pgDbApi", () => {
                 about: insertedUser.about,
                 isPublic: insertedUser.isPublic,
                 declarations: expectedDeclarations,
-                sub: null
+                sub: null,
+                role: "user"
             });
 
             const updatedUser: DbUser = {
@@ -448,7 +450,8 @@ describe("pgDbApi", () => {
                 about: "updated about",
                 email: "updated@test.com",
                 isPublic: !insertedUser.isPublic,
-                sub: null
+                sub: null,
+                role: "user"
             };
 
             console.log("updating user");

--- a/api/src/core/ports/DbApiV2.ts
+++ b/api/src/core/ports/DbApiV2.ts
@@ -18,6 +18,7 @@ import type { OmitFromExisting } from "../utils";
 import type { CompiledData } from "./CompileData";
 
 import type { SoftwareExternal } from "../types/SoftwareTypes";
+import type { UserRole } from "../adapters/dbApi/kysely/kysely.database";
 import type { AttributeDefinition } from "../usecases/readWriteSillData/attributeTypes";
 import { SoftwareExternalDataOption } from "./GetSoftwareExternalDataOptions";
 import type { Os, RuntimePlatform } from "../types";
@@ -152,6 +153,7 @@ export type DbUser = {
     organization: string | null;
     about: string | undefined;
     isPublic: boolean;
+    role: UserRole;
 };
 
 export interface UserRepository {
@@ -212,6 +214,8 @@ export interface SessionRepository {
 export interface AttributeDefinitionRepository {
     getAll: () => Promise<AttributeDefinition[]>;
     getByName: (name: string) => Promise<AttributeDefinition | undefined>;
+    add: (def: AttributeDefinition) => Promise<void>;
+    update: (name: string, patch: Partial<Omit<AttributeDefinition, "name" | "kind" | "createdAt">>) => Promise<void>;
 }
 
 export type DbApiV2 = {

--- a/api/src/core/usecases/auth/handleAuthCallback.ts
+++ b/api/src/core/usecases/auth/handleAuthCallback.ts
@@ -50,7 +50,8 @@ export const makeHandleAuthCallback = ({
                 lastName: userInfoFromProvider.family_name ?? userInfoFromProvider.usual_name,
                 organization: null,
                 isPublic: false,
-                about: undefined
+                about: undefined,
+                role: "user"
             });
         } else {
             userId = user.id;

--- a/api/src/core/usecases/createSoftware.test.ts
+++ b/api/src/core/usecases/createSoftware.test.ts
@@ -62,7 +62,8 @@ describe("Create software - Trying all the cases", () => {
             organization: "myorg",
             about: "my about",
             isPublic: false,
-            sub: null
+            sub: null,
+            role: "user"
         });
 
         createSoftware = makeCreateSofware(dbApi);

--- a/api/src/core/usecases/getUser.unit.test.ts
+++ b/api/src/core/usecases/getUser.unit.test.ts
@@ -20,7 +20,8 @@ describe("getUser", () => {
         isPublic: false,
         about: "",
         declarations: [],
-        sub: null
+        sub: null,
+        role: "user"
     };
 
     const publicUser: UserWithId = {
@@ -30,7 +31,8 @@ describe("getUser", () => {
         isPublic: true,
         about: "",
         declarations: [],
-        sub: null
+        sub: null,
+        role: "user"
     };
 
     const currentUser: UserWithId = {
@@ -40,7 +42,8 @@ describe("getUser", () => {
         about: undefined,
         organization: null,
         sub: "user-id",
-        email: "bob@mail.com"
+        email: "bob@mail.com",
+        role: "user"
     };
 
     let userRepository: UserRepository;

--- a/api/src/core/usecases/importFromSource.ts
+++ b/api/src/core/usecases/importFromSource.ts
@@ -32,7 +32,8 @@ export const importFromSource: (dbApi: DbApiV2) => ImportFromSource = (dbApi: Db
                   "isPublic": false,
                   organization: "",
                   about: "This is a bot user created to import data.",
-                  sub: null
+                  sub: null,
+                  role: "user"
               });
 
         let result = [];

--- a/api/src/core/usecases/readWriteSillData/attributeTypes.ts
+++ b/api/src/core/usecases/readWriteSillData/attributeTypes.ts
@@ -12,6 +12,7 @@ export type AttributeDefinition = {
     label: LocalizedString;
     description?: LocalizedString;
     displayInForm: boolean;
+    editableByAdminOnly: boolean;
     displayInDetails: boolean;
     displayInCardIcon: "computer" | "france" | "question" | "thumbs-up" | "chat" | "star" | undefined;
     enableFiltering: boolean;

--- a/api/src/core/usecases/readWriteSillData/types.ts
+++ b/api/src/core/usecases/readWriteSillData/types.ts
@@ -10,7 +10,8 @@ import {
     SchemaIdentifier,
     SchemaOrganization,
     SchemaPerson,
-    ScholarlyArticle
+    ScholarlyArticle,
+    UserRole
 } from "../../adapters/dbApi/kysely/kysely.database";
 import { CustomAttributes } from "./attributeTypes";
 import type { SoftwareExternalDataOption } from "../../ports/GetSoftwareExternalDataOptions";
@@ -109,6 +110,7 @@ export type CreateUserParams = {
     isPublic: boolean;
     about: string | undefined;
     sub: string | null;
+    role: UserRole;
 };
 
 export type UserWithId = CreateUserParams & { id: number };

--- a/api/src/core/usecases/refreshExternalData.test.ts
+++ b/api/src/core/usecases/refreshExternalData.test.ts
@@ -140,7 +140,8 @@ describe("fetches software extra data (from different providers)", () => {
             organization: "myorg",
             about: "my about",
             isPublic: false,
-            sub: null
+            sub: null,
+            role: "user"
         });
 
         const makeSoftware = makeCreateSofware(dbApi);

--- a/api/src/core/usecases/sanitizeSoftwareFormDataCustomAttributes.ts
+++ b/api/src/core/usecases/sanitizeSoftwareFormDataCustomAttributes.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import type { DbApiV2 } from "../ports/DbApiV2";
+import type { SoftwareFormData } from "./readWriteSillData";
+
+export const sanitizeSoftwareFormDataCustomAttributes = async ({
+    dbApi,
+    formData,
+    isAdmin,
+    softwareId
+}: {
+    dbApi: DbApiV2;
+    formData: SoftwareFormData;
+    isAdmin: boolean;
+    softwareId?: number;
+}): Promise<SoftwareFormData> => {
+    if (isAdmin) return formData;
+
+    const adminOnlyNames = await getAdminOnlyAttributeNames({ dbApi });
+    if (adminOnlyNames.length === 0) return formData;
+
+    const editableCustomAttributes = removeAdminOnlyAttributes({
+        customAttributes: formData.customAttributes ?? {},
+        adminOnlyNames
+    });
+
+    if (softwareId === undefined) {
+        return { ...formData, customAttributes: editableCustomAttributes };
+    }
+
+    const existingSoftware = await dbApi.software.getBySoftwareId(softwareId);
+    const customAttributes = restoreExistingAdminOnlyAttributes({
+        customAttributes: editableCustomAttributes,
+        existingCustomAttributes: existingSoftware?.customAttributes ?? {},
+        adminOnlyNames
+    });
+
+    return { ...formData, customAttributes };
+};
+
+const getAdminOnlyAttributeNames = async ({ dbApi }: { dbApi: DbApiV2 }): Promise<string[]> =>
+    (await dbApi.attributeDefinition.getAll()).filter(def => def.editableByAdminOnly).map(def => def.name);
+
+const removeAdminOnlyAttributes = ({
+    customAttributes,
+    adminOnlyNames
+}: {
+    customAttributes: NonNullable<SoftwareFormData["customAttributes"]>;
+    adminOnlyNames: string[];
+}): NonNullable<SoftwareFormData["customAttributes"]> => {
+    const adminOnlyNameSet = new Set(adminOnlyNames);
+
+    return Object.fromEntries(Object.entries(customAttributes).filter(([name]) => !adminOnlyNameSet.has(name)));
+};
+
+const restoreExistingAdminOnlyAttributes = ({
+    customAttributes,
+    existingCustomAttributes,
+    adminOnlyNames
+}: {
+    customAttributes: NonNullable<SoftwareFormData["customAttributes"]>;
+    existingCustomAttributes: NonNullable<SoftwareFormData["customAttributes"]>;
+    adminOnlyNames: string[];
+}): NonNullable<SoftwareFormData["customAttributes"]> => {
+    const restoredCustomAttributes = { ...customAttributes };
+
+    for (const name of adminOnlyNames) {
+        if (Object.hasOwn(existingCustomAttributes, name)) {
+            restoredCustomAttributes[name] = existingCustomAttributes[name];
+        }
+    }
+
+    return restoredCustomAttributes;
+};

--- a/api/src/core/usecases/updateSoftware.test.ts
+++ b/api/src/core/usecases/updateSoftware.test.ts
@@ -63,7 +63,8 @@ describe("Create software, than updates it adding a similar software", () => {
             organization: "myorg",
             about: "my about",
             isPublic: false,
-            sub: null
+            sub: null,
+            role: "user"
         });
 
         createSoftware = makeCreateSofware(dbApi);

--- a/api/src/lib/ApiTypes.ts
+++ b/api/src/lib/ApiTypes.ts
@@ -12,7 +12,8 @@ export type {
     SchemaPerson as Person,
     SchemaOrganization as Organization,
     ScholarlyArticle,
-    RepoMetadata
+    RepoMetadata,
+    UserRole
 } from "../core/adapters/dbApi/kysely/kysely.database";
 
 export type {

--- a/api/src/rpc/createTestCaller.ts
+++ b/api/src/rpc/createTestCaller.ts
@@ -23,7 +23,8 @@ export const defaultUser: UserWithId = {
     organization: "default",
     isPublic: false,
     about: "",
-    declarations: []
+    declarations: [],
+    role: "user"
 };
 
 export type ApiCaller = Awaited<ReturnType<typeof createTestCaller>>["apiCaller"];

--- a/api/src/rpc/router.ts
+++ b/api/src/rpc/router.ts
@@ -8,7 +8,7 @@ import superjson from "superjson";
 import type { Equals, ReturnType } from "tsafe";
 import { assert } from "tsafe/assert";
 import { z } from "zod";
-import { DbApiV2 } from "../core/ports/DbApiV2";
+import type { DbApiV2 } from "../core/ports/DbApiV2";
 import { Language } from "../core/ports/GetSoftwareExternalData";
 import { UiConfig } from "../core/uiConfigSchema";
 import type { UseCases } from "../core/usecases";
@@ -25,6 +25,7 @@ import type { Context } from "./context";
 import type { OidcParams } from "../core/usecases/auth/oidcClient";
 import { resolveAdapterFromSource } from "../core/adapters/resolveAdapter";
 import { softwareExternalDataOptionSchema } from "../core/ports/GetSoftwareExternalDataOptions";
+import { sanitizeSoftwareFormDataCustomAttributes } from "../core/usecases/sanitizeSoftwareFormDataCustomAttributes";
 
 export type UseCasesUsedOnRouter = Pick<
     UseCases,
@@ -222,8 +223,14 @@ export function createRouter(params: {
                 }
 
                 try {
-                    const createdSoftwareId = await useCases.createSoftware({
+                    const sanitizedFormData = await sanitizeSoftwareFormDataCustomAttributes({
+                        dbApi,
                         formData,
+                        isAdmin: currentUser.role === "admin"
+                    });
+
+                    const createdSoftwareId = await useCases.createSoftware({
+                        formData: sanitizedFormData,
                         userId: currentUser.id
                     });
 
@@ -245,9 +252,16 @@ export function createRouter(params: {
             .mutation(async ({ ctx: { currentUser }, input }) => {
                 const { softwareSillId, formData } = input;
 
+                const sanitizedFormData = await sanitizeSoftwareFormDataCustomAttributes({
+                    dbApi,
+                    formData,
+                    isAdmin: currentUser.role === "admin",
+                    softwareId: softwareSillId
+                });
+
                 await useCases.updateSoftware({
                     softwareId: softwareSillId,
-                    formData,
+                    formData: sanitizedFormData,
                     userId: currentUser.id
                 });
             }),
@@ -469,6 +483,7 @@ export function createRouter(params: {
                 label: input.label,
                 description: input.description,
                 displayInForm: input.displayInForm,
+                editableByAdminOnly: input.editableByAdminOnly,
                 displayInDetails: input.displayInDetails,
                 displayInCardIcon: input.displayInCardIcon,
                 enableFiltering: input.enableFiltering,
@@ -619,6 +634,7 @@ const zAttributeDefinitionCreate = z.object({
     "label": zLocalizedString,
     "description": zLocalizedString.optional(),
     "displayInForm": z.boolean(),
+    "editableByAdminOnly": z.boolean().default(false),
     "displayInDetails": z.boolean(),
     "displayInCardIcon": zDisplayInCardIcon.optional(),
     "enableFiltering": z.boolean(),
@@ -631,6 +647,7 @@ const zAttributeDefinitionUpdate = z.object({
     "label": zLocalizedString.optional(),
     "description": zLocalizedString.optional(),
     "displayInForm": z.boolean().optional(),
+    "editableByAdminOnly": z.boolean().optional(),
     "displayInDetails": z.boolean().optional(),
     "displayInCardIcon": zDisplayInCardIcon.optional(),
     "enableFiltering": z.boolean().optional(),

--- a/api/src/rpc/router.ts
+++ b/api/src/rpc/router.ts
@@ -111,6 +111,18 @@ export function createRouter(params: {
         })
     );
 
+    const adminProcedure = protectedProcedure.use(
+        t.middleware(async ({ ctx, next }) => {
+            if (!ctx.currentUser || ctx.currentUser.role !== "admin") throw new TRPCError({ "code": "FORBIDDEN" });
+            return next({
+                ctx: {
+                    ...ctx,
+                    currentUser: ctx.currentUser
+                }
+            });
+        })
+    );
+
     const router = t.router({
         // PUBLIC PROCEDURES
         "getRedirectUrl": loggedProcedure.query(() => redirectUrl),
@@ -428,7 +440,66 @@ export function createRouter(params: {
                     time: new Date().toISOString(),
                     dereferencedByUserId: currentUser.id
                 });
-            })
+            }),
+
+        "getAttributeDefinitions": loggedProcedure.query(() => dbApi.attributeDefinition.getAll()),
+
+        "createAttributeDefinition": adminProcedure.input(zAttributeDefinitionCreate).mutation(async ({ input }) => {
+            const existing = await dbApi.attributeDefinition.getByName(input.name);
+            if (existing) {
+                throw new TRPCError({
+                    "code": "CONFLICT",
+                    "message": `An attribute with name "${input.name}" already exists.`
+                });
+            }
+
+            const all = await dbApi.attributeDefinition.getAll();
+            const orderClash = all.find(a => a.displayOrder === input.displayOrder);
+            if (orderClash) {
+                throw new TRPCError({
+                    "code": "CONFLICT",
+                    "message": `Display order ${input.displayOrder} is already used by "${orderClash.name}".`
+                });
+            }
+
+            const now = new Date();
+            await dbApi.attributeDefinition.add({
+                name: input.name,
+                kind: input.kind,
+                label: input.label,
+                description: input.description,
+                displayInForm: input.displayInForm,
+                displayInDetails: input.displayInDetails,
+                displayInCardIcon: input.displayInCardIcon,
+                enableFiltering: input.enableFiltering,
+                required: input.required,
+                displayOrder: input.displayOrder,
+                createdAt: now,
+                updatedAt: now
+            });
+        }),
+
+        "updateAttributeDefinition": adminProcedure.input(zAttributeDefinitionUpdate).mutation(async ({ input }) => {
+            const { name, ...patch } = input;
+            const existing = await dbApi.attributeDefinition.getByName(name);
+            if (!existing) {
+                throw new TRPCError({
+                    "code": "NOT_FOUND",
+                    "message": `No attribute with name "${name}".`
+                });
+            }
+            if (patch.displayOrder !== undefined && patch.displayOrder !== existing.displayOrder) {
+                const all = await dbApi.attributeDefinition.getAll();
+                const orderClash = all.find(a => a.name !== name && a.displayOrder === patch.displayOrder);
+                if (orderClash) {
+                    throw new TRPCError({
+                        "code": "CONFLICT",
+                        "message": `Display order ${patch.displayOrder} is already used by "${orderClash.name}".`
+                    });
+                }
+            }
+            await dbApi.attributeDefinition.update(name, patch);
+        })
     });
 
     return { router };
@@ -534,6 +605,38 @@ const zInstanceFormData = (() => {
 
     return zOut as z.ZodType<InstanceFormData>;
 })();
+
+const zAttributeKind = z.enum(["boolean", "string", "number", "date", "url"]);
+const zDisplayInCardIcon = z.enum(["computer", "france", "question", "thumbs-up", "chat", "star"]);
+const zLocalizedString = z.record(z.string(), z.string());
+
+const zAttributeDefinitionCreate = z.object({
+    "name": z
+        .string()
+        .min(1)
+        .regex(/^[a-zA-Z][a-zA-Z0-9]*$/, "name must start with a letter and contain only alphanumeric characters"),
+    "kind": zAttributeKind,
+    "label": zLocalizedString,
+    "description": zLocalizedString.optional(),
+    "displayInForm": z.boolean(),
+    "displayInDetails": z.boolean(),
+    "displayInCardIcon": zDisplayInCardIcon.optional(),
+    "enableFiltering": z.boolean(),
+    "required": z.boolean(),
+    "displayOrder": z.number().int()
+});
+
+const zAttributeDefinitionUpdate = z.object({
+    "name": z.string().min(1),
+    "label": zLocalizedString.optional(),
+    "description": zLocalizedString.optional(),
+    "displayInForm": z.boolean().optional(),
+    "displayInDetails": z.boolean().optional(),
+    "displayInCardIcon": zDisplayInCardIcon.optional(),
+    "enableFiltering": z.boolean().optional(),
+    "required": z.boolean().optional(),
+    "displayOrder": z.number().int().optional()
+});
 
 const zLanguage = z.union([z.literal("fr"), z.literal("en")]);
 

--- a/api/src/rpc/routes.e2e.test.ts
+++ b/api/src/rpc/routes.e2e.test.ts
@@ -82,6 +82,268 @@ describe("RPC e2e tests", () => {
         });
     });
 
+    describe("admin-only custom attributes", () => {
+        const adminUser: typeof defaultUser = {
+            ...defaultUser,
+            id: 1,
+            email: "admin.user@mail.com",
+            role: "admin"
+        };
+
+        const insertAttributeDefinition = async (params: {
+            name: string;
+            editableByAdminOnly: boolean;
+            displayOrder: number;
+        }) => {
+            await kyselyDb.deleteFrom("software_attribute_definitions").where("name", "=", params.name).execute();
+            await kyselyDb
+                .insertInto("software_attribute_definitions")
+                .values({
+                    name: params.name,
+                    kind: "boolean",
+                    label: JSON.stringify({ en: params.name, fr: params.name }),
+                    description: null,
+                    displayInForm: true,
+                    editableByAdminOnly: params.editableByAdminOnly,
+                    displayInDetails: true,
+                    displayInCardIcon: null,
+                    enableFiltering: true,
+                    required: false,
+                    displayOrder: params.displayOrder,
+                    createdAt: new Date(),
+                    updatedAt: new Date()
+                })
+                .execute();
+        };
+
+        const insertSoftwareRow = async (params: {
+            name: string;
+            customAttributes: Record<string, unknown>;
+            userId: number;
+        }) => {
+            const now = new Date().toISOString();
+            const row = await kyselyDb
+                .insertInto("softwares")
+                .values({
+                    name: params.name,
+                    addedTime: now,
+                    updateTime: now,
+                    dereferencing: null,
+                    isStillInObservation: false,
+                    customAttributes: JSON.stringify(params.customAttributes),
+                    addedByUserId: params.userId
+                })
+                .returning("id")
+                .executeTakeFirstOrThrow();
+            return row.id;
+        };
+
+        it("allows admins to create and update the admin-only editability flag", async () => {
+            ({ kyselyDb } = await createTestCaller({ currentUser: undefined }));
+            await resetDB(kyselyDb);
+            ({ apiCaller, kyselyDb } = await createTestCaller({ db: kyselyDb, currentUser: adminUser }));
+
+            await kyselyDb
+                .deleteFrom("software_attribute_definitions")
+                .where("name", "=", "adminOnlyRouteFlag")
+                .execute();
+
+            await apiCaller.createAttributeDefinition({
+                name: "adminOnlyRouteFlag",
+                kind: "boolean",
+                label: { en: "Admin only route flag", fr: "Admin only route flag" },
+                displayInForm: true,
+                editableByAdminOnly: true,
+                displayInDetails: true,
+                enableFiltering: false,
+                required: false,
+                displayOrder: 701
+            });
+
+            expect(await apiCaller.getAttributeDefinitions()).toContainEqual(
+                expect.objectContaining({
+                    name: "adminOnlyRouteFlag",
+                    editableByAdminOnly: true
+                })
+            );
+
+            await apiCaller.updateAttributeDefinition({
+                name: "adminOnlyRouteFlag",
+                editableByAdminOnly: false
+            });
+
+            expect(await apiCaller.getAttributeDefinitions()).toContainEqual(
+                expect.objectContaining({
+                    name: "adminOnlyRouteFlag",
+                    editableByAdminOnly: false
+                })
+            );
+        });
+
+        it("ignores admin-only custom attributes on non-admin software creation", async () => {
+            ({ kyselyDb } = await createTestCaller({ currentUser: undefined }));
+            await resetDB(kyselyDb);
+            ({ apiCaller, kyselyDb } = await createTestCaller({ db: kyselyDb, currentUser: defaultUser }));
+            await insertAttributeDefinition({
+                name: "adminOnlyCreateFlag",
+                editableByAdminOnly: true,
+                displayOrder: 702
+            });
+            await insertAttributeDefinition({
+                name: "publicCreateFlag",
+                editableByAdminOnly: false,
+                displayOrder: 703
+            });
+
+            await apiCaller.createSoftware({
+                formData: createSoftwareFormData({
+                    sourceSlug: testSource.slug,
+                    name: "Admin only create test",
+                    similarSoftwareExternalDataItems: [],
+                    customAttributes: {
+                        adminOnlyCreateFlag: true,
+                        publicCreateFlag: true
+                    }
+                })
+            });
+
+            const software = await kyselyDb
+                .selectFrom("softwares")
+                .selectAll()
+                .where("name", "=", "Admin only create test")
+                .executeTakeFirstOrThrow();
+
+            expect(software.customAttributes).toEqual({ publicCreateFlag: true });
+        });
+
+        it("preserves admin-only custom attributes on non-admin software updates", async () => {
+            ({ kyselyDb } = await createTestCaller({ currentUser: undefined }));
+            await resetDB(kyselyDb);
+            ({ apiCaller, kyselyDb } = await createTestCaller({ db: kyselyDb, currentUser: defaultUser }));
+            await insertAttributeDefinition({
+                name: "adminOnlyUpdateFlag",
+                editableByAdminOnly: true,
+                displayOrder: 704
+            });
+            await insertAttributeDefinition({
+                name: "publicUpdateFlag",
+                editableByAdminOnly: false,
+                displayOrder: 705
+            });
+            const softwareId = await insertSoftwareRow({
+                name: "Admin only update test",
+                customAttributes: {
+                    adminOnlyUpdateFlag: null,
+                    publicUpdateFlag: true
+                },
+                userId: defaultUser.id
+            });
+
+            await apiCaller.updateSoftware({
+                softwareSillId: softwareId,
+                formData: createSoftwareFormData({
+                    sourceSlug: testSource.slug,
+                    name: "Admin only update test",
+                    similarSoftwareExternalDataItems: [],
+                    customAttributes: {
+                        adminOnlyUpdateFlag: false,
+                        publicUpdateFlag: false
+                    }
+                })
+            });
+
+            const software = await kyselyDb
+                .selectFrom("softwares")
+                .selectAll()
+                .where("id", "=", softwareId)
+                .executeTakeFirstOrThrow();
+
+            expect(software.customAttributes).toEqual({
+                adminOnlyUpdateFlag: null,
+                publicUpdateFlag: false
+            });
+        });
+
+        it("preserves omitted admin-only custom attributes on non-admin software updates", async () => {
+            ({ kyselyDb } = await createTestCaller({ currentUser: undefined }));
+            await resetDB(kyselyDb);
+            ({ apiCaller, kyselyDb } = await createTestCaller({ db: kyselyDb, currentUser: defaultUser }));
+            await insertAttributeDefinition({
+                name: "adminOnlyOmittedFlag",
+                editableByAdminOnly: true,
+                displayOrder: 706
+            });
+            await insertAttributeDefinition({
+                name: "publicOmittedFlag",
+                editableByAdminOnly: false,
+                displayOrder: 707
+            });
+            const softwareId = await insertSoftwareRow({
+                name: "Admin only omitted update test",
+                customAttributes: {
+                    adminOnlyOmittedFlag: true,
+                    publicOmittedFlag: true
+                },
+                userId: defaultUser.id
+            });
+
+            await apiCaller.updateSoftware({
+                softwareSillId: softwareId,
+                formData: createSoftwareFormData({
+                    sourceSlug: testSource.slug,
+                    name: "Admin only omitted update test",
+                    similarSoftwareExternalDataItems: [],
+                    customAttributes: { publicOmittedFlag: false }
+                })
+            });
+
+            const software = await kyselyDb
+                .selectFrom("softwares")
+                .selectAll()
+                .where("id", "=", softwareId)
+                .executeTakeFirstOrThrow();
+
+            expect(software.customAttributes).toEqual({
+                adminOnlyOmittedFlag: true,
+                publicOmittedFlag: false
+            });
+        });
+
+        it("allows admins to update admin-only custom attributes", async () => {
+            ({ kyselyDb } = await createTestCaller({ currentUser: undefined }));
+            await resetDB(kyselyDb);
+            ({ apiCaller, kyselyDb } = await createTestCaller({ db: kyselyDb, currentUser: adminUser }));
+            await insertAttributeDefinition({
+                name: "adminOnlyAdminFlag",
+                editableByAdminOnly: true,
+                displayOrder: 706
+            });
+            const softwareId = await insertSoftwareRow({
+                name: "Admin can update admin-only test",
+                customAttributes: { adminOnlyAdminFlag: false },
+                userId: adminUser.id
+            });
+
+            await apiCaller.updateSoftware({
+                softwareSillId: softwareId,
+                formData: createSoftwareFormData({
+                    sourceSlug: testSource.slug,
+                    name: "Admin can update admin-only test",
+                    similarSoftwareExternalDataItems: [],
+                    customAttributes: { adminOnlyAdminFlag: true }
+                })
+            });
+
+            const software = await kyselyDb
+                .selectFrom("softwares")
+                .selectAll()
+                .where("id", "=", softwareId)
+                .executeTakeFirstOrThrow();
+
+            expect(software.customAttributes).toEqual({ adminOnlyAdminFlag: true });
+        });
+    });
+
     // ⚠️ reminder : you need to run the whole scenarios
     // because those tests are not isolated
     // (the order is important)⚠️

--- a/api/src/rpc/translations/en_default.json
+++ b/api/src/rpc/translations/en_default.json
@@ -403,7 +403,57 @@
         "login": "Login",
         "register": "Register",
         "logout": "Logout",
-        "account": "My account"
+        "account": "My account",
+        "admin": "Admin"
+    },
+    "admin": {
+        "title": "Administration",
+        "customAttributes": {
+            "title": "Custom attributes",
+            "subtitle": "Manage the custom fields available on software entries.",
+            "addAttribute": "Add a field",
+            "columnName": "Identifier",
+            "columnKind": "Type",
+            "columnLabel": "Label",
+            "columnDisplayInForm": "Form",
+            "columnDisplayInDetails": "Detail",
+            "columnEnableFiltering": "Filter",
+            "columnRequired": "Required",
+            "columnDisplayInCardIcon": "Icon",
+            "columnDisplayOrder": "Order",
+            "columnActions": "Actions",
+            "edit": "Edit",
+            "empty": "No custom attribute defined yet."
+        },
+        "form": {
+            "createTitle": "Add a custom attribute",
+            "editTitle": "Edit a custom attribute",
+            "sectionIdentifier": "Identifier",
+            "sectionDisplay": "Display",
+            "sectionBehavior": "Behavior",
+            "name": "Identifier",
+            "nameHint": "letters and digits only, must start with a letter",
+            "lockedAfterCreate": "Cannot be changed after creation.",
+            "namePlaceholder": "isFromFrenchPublicService",
+            "kind": "Type",
+            "labelFr": "Label (FR)",
+            "labelEn": "Label (EN)",
+            "descriptionFr": "Description (FR)",
+            "descriptionEn": "Description (EN)",
+            "displayInForm": "Show in software form",
+            "displayInDetails": "Show in software detail page",
+            "enableFiltering": "Enable filtering in catalog",
+            "required": "Required field",
+            "displayInCardIcon": "Icon in the results list",
+            "iconNone": "none",
+            "displayOrder": "Display order",
+            "save": "Save",
+            "cancel": "Cancel",
+            "errors": {
+                "invalidName": "Identifier must start with a letter and contain only letters and digits.",
+                "labelRequired": "FR and EN labels are required."
+            }
+        }
     },
     "authorCard": {
         "affiliatedStructure": "Affiliated structures"

--- a/api/src/rpc/translations/en_default.json
+++ b/api/src/rpc/translations/en_default.json
@@ -99,7 +99,9 @@
         "add software": "Add {{name}}",
         "update software": "Update {{name}}",
         "add software button": "Add {{name}} to the $t(common.appAccronym)",
-        "update software button": "Update {{name}}"
+        "update software button": "Update {{name}}",
+        "adminOnlyCustomAttributeBadge": "Admin-only field",
+        "adminOnlyCustomAttributeHint": "You are editing this field with administrator privileges. Non-admin contributors cannot change it."
     },
     "softwareFormStep1": {
         "software desktop": "Desktop or mobile installable software",
@@ -416,6 +418,9 @@
             "columnKind": "Type",
             "columnLabel": "Label",
             "columnDisplayInForm": "Form",
+            "columnEditableBy": "Editable by",
+            "editableByEveryone": "Everyone",
+            "editableByAdminOnly": "Admins only",
             "columnDisplayInDetails": "Detail",
             "columnEnableFiltering": "Filter",
             "columnRequired": "Required",
@@ -441,6 +446,7 @@
             "descriptionFr": "Description (FR)",
             "descriptionEn": "Description (EN)",
             "displayInForm": "Show in software form",
+            "editableByAdminOnly": "Editable by administrators only",
             "displayInDetails": "Show in software detail page",
             "enableFiltering": "Enable filtering in catalog",
             "required": "Required field",

--- a/api/src/rpc/translations/fr_default.json
+++ b/api/src/rpc/translations/fr_default.json
@@ -410,7 +410,57 @@
         "login": "Se connecter",
         "register": "Créer un compte",
         "logout": "Se déconnecter",
-        "account": "Mon compte"
+        "account": "Mon compte",
+        "admin": "Admin"
+    },
+    "admin": {
+        "title": "Administration",
+        "customAttributes": {
+            "title": "Attributs personnalisés",
+            "subtitle": "Gérez les champs personnalisés disponibles sur les fiches logiciel.",
+            "addAttribute": "Ajouter un champ",
+            "columnName": "Identifiant",
+            "columnKind": "Type",
+            "columnLabel": "Libellé",
+            "columnDisplayInForm": "Formulaire",
+            "columnDisplayInDetails": "Détail",
+            "columnEnableFiltering": "Filtre",
+            "columnRequired": "Requis",
+            "columnDisplayInCardIcon": "Icône",
+            "columnDisplayOrder": "Ordre",
+            "columnActions": "Actions",
+            "edit": "Modifier",
+            "empty": "Aucun attribut personnalisé défini."
+        },
+        "form": {
+            "createTitle": "Ajouter un attribut personnalisé",
+            "editTitle": "Modifier un attribut personnalisé",
+            "sectionIdentifier": "Identifiant",
+            "sectionDisplay": "Affichage",
+            "sectionBehavior": "Comportement",
+            "name": "Identifiant",
+            "nameHint": "lettres et chiffres uniquement, doit commencer par une lettre",
+            "lockedAfterCreate": "Ne sera plus modifiable après création.",
+            "namePlaceholder": "isFromFrenchPublicService",
+            "kind": "Type",
+            "labelFr": "Libellé (FR)",
+            "labelEn": "Libellé (EN)",
+            "descriptionFr": "Description (FR)",
+            "descriptionEn": "Description (EN)",
+            "displayInForm": "Afficher dans le formulaire logiciel",
+            "displayInDetails": "Afficher sur la fiche détail",
+            "enableFiltering": "Activer le filtrage dans le catalogue",
+            "required": "Champ obligatoire",
+            "displayInCardIcon": "Icône dans la liste des résultats",
+            "iconNone": "aucune",
+            "displayOrder": "Ordre d'affichage",
+            "save": "Enregistrer",
+            "cancel": "Annuler",
+            "errors": {
+                "invalidName": "L'identifiant doit commencer par une lettre et ne contenir que des lettres et chiffres.",
+                "labelRequired": "Les libellés FR et EN sont obligatoires."
+            }
+        }
     },
     "authorCard": {
         "affiliatedStructure": "Structures associées"

--- a/api/src/rpc/translations/fr_default.json
+++ b/api/src/rpc/translations/fr_default.json
@@ -101,7 +101,9 @@
         "add software": "Ajouter {{name}}",
         "update software": "Mettre à jour {{name}}",
         "add software button": "Ajouter {{name}} au $t(common.appAccronym)",
-        "update software button": "Mettre à jour {{name}}"
+        "update software button": "Mettre à jour {{name}}",
+        "adminOnlyCustomAttributeBadge": "Champ administrateur",
+        "adminOnlyCustomAttributeHint": "Vous modifiez ce champ avec des droits administrateur. Les contributeurs non administrateurs ne peuvent pas le modifier."
     },
     "softwareFormStep1": {
         "software desktop": "Logiciel installable sur poste de travail",
@@ -423,6 +425,9 @@
             "columnKind": "Type",
             "columnLabel": "Libellé",
             "columnDisplayInForm": "Formulaire",
+            "columnEditableBy": "Modifiable par",
+            "editableByEveryone": "Tout le monde",
+            "editableByAdminOnly": "Admin uniquement",
             "columnDisplayInDetails": "Détail",
             "columnEnableFiltering": "Filtre",
             "columnRequired": "Requis",
@@ -448,6 +453,7 @@
             "descriptionFr": "Description (FR)",
             "descriptionEn": "Description (EN)",
             "displayInForm": "Afficher dans le formulaire logiciel",
+            "editableByAdminOnly": "Modifiable uniquement par les administrateurs",
             "displayInDetails": "Afficher sur la fiche détail",
             "enableFiltering": "Activer le filtrage dans le catalogue",
             "required": "Champ obligatoire",

--- a/api/src/rpc/translations/schema.json
+++ b/api/src/rpc/translations/schema.json
@@ -415,6 +415,12 @@
                 "update software button": {
                     "type": "string",
                     "description": "Text for a button"
+                },
+                "adminOnlyCustomAttributeBadge": {
+                    "type": "string"
+                },
+                "adminOnlyCustomAttributeHint": {
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -432,7 +438,9 @@
                 "add software",
                 "update software",
                 "add software button",
-                "update software button"
+                "update software button",
+                "adminOnlyCustomAttributeBadge",
+                "adminOnlyCustomAttributeHint"
             ]
         },
         "softwareFormStep1": {
@@ -523,24 +531,21 @@
                     "type": "string"
                 },
                 "source external": {
-                    "type": "string",
-                    "description": "Hint shown under a field whose value is provided by an external source (state 2)."
+                    "type": "string"
                 },
                 "source user input": {
-                    "type": "string",
-                    "description": "Hint shown under a field that the user explicitly overrode (state 3)."
+                    "type": "string"
                 },
                 "override field title": {
                     "type": "string",
-                    "description": "Tooltip on the pencil icon that opens the override-warning modal."
+                    "description": "Title text"
                 },
                 "cancel override title": {
                     "type": "string",
-                    "description": "Tooltip on the cross icon that reverts an override back to the external source value."
+                    "description": "Title text"
                 },
                 "keywords from source": {
-                    "type": "string",
-                    "description": "Hint listing keywords contributed by an external source (union-merged with the user's own keywords)."
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -1654,10 +1659,227 @@
                 },
                 "account": {
                     "type": "string"
+                },
+                "admin": {
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
-            "required": ["login", "register", "logout", "account"]
+            "required": ["login", "register", "logout", "account", "admin"]
+        },
+        "admin": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Title text"
+                },
+                "customAttributes": {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Title text"
+                        },
+                        "subtitle": {
+                            "type": "string",
+                            "description": "Title text"
+                        },
+                        "addAttribute": {
+                            "type": "string"
+                        },
+                        "columnName": {
+                            "type": "string"
+                        },
+                        "columnKind": {
+                            "type": "string"
+                        },
+                        "columnLabel": {
+                            "type": "string"
+                        },
+                        "columnDisplayInForm": {
+                            "type": "string"
+                        },
+                        "columnEditableBy": {
+                            "type": "string"
+                        },
+                        "editableByEveryone": {
+                            "type": "string"
+                        },
+                        "editableByAdminOnly": {
+                            "type": "string"
+                        },
+                        "columnDisplayInDetails": {
+                            "type": "string"
+                        },
+                        "columnEnableFiltering": {
+                            "type": "string"
+                        },
+                        "columnRequired": {
+                            "type": "string"
+                        },
+                        "columnDisplayInCardIcon": {
+                            "type": "string"
+                        },
+                        "columnDisplayOrder": {
+                            "type": "string"
+                        },
+                        "columnActions": {
+                            "type": "string"
+                        },
+                        "edit": {
+                            "type": "string"
+                        },
+                        "empty": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "title",
+                        "subtitle",
+                        "addAttribute",
+                        "columnName",
+                        "columnKind",
+                        "columnLabel",
+                        "columnDisplayInForm",
+                        "columnEditableBy",
+                        "editableByEveryone",
+                        "editableByAdminOnly",
+                        "columnDisplayInDetails",
+                        "columnEnableFiltering",
+                        "columnRequired",
+                        "columnDisplayInCardIcon",
+                        "columnDisplayOrder",
+                        "columnActions",
+                        "edit",
+                        "empty"
+                    ]
+                },
+                "form": {
+                    "type": "object",
+                    "properties": {
+                        "createTitle": {
+                            "type": "string"
+                        },
+                        "editTitle": {
+                            "type": "string"
+                        },
+                        "sectionIdentifier": {
+                            "type": "string"
+                        },
+                        "sectionDisplay": {
+                            "type": "string"
+                        },
+                        "sectionBehavior": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "nameHint": {
+                            "type": "string"
+                        },
+                        "lockedAfterCreate": {
+                            "type": "string"
+                        },
+                        "namePlaceholder": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "type": "string"
+                        },
+                        "labelFr": {
+                            "type": "string",
+                            "description": "Label for a form field or button"
+                        },
+                        "labelEn": {
+                            "type": "string",
+                            "description": "Label for a form field or button"
+                        },
+                        "descriptionFr": {
+                            "type": "string"
+                        },
+                        "descriptionEn": {
+                            "type": "string"
+                        },
+                        "displayInForm": {
+                            "type": "string"
+                        },
+                        "editableByAdminOnly": {
+                            "type": "string"
+                        },
+                        "displayInDetails": {
+                            "type": "string"
+                        },
+                        "enableFiltering": {
+                            "type": "string"
+                        },
+                        "required": {
+                            "type": "string"
+                        },
+                        "displayInCardIcon": {
+                            "type": "string"
+                        },
+                        "iconNone": {
+                            "type": "string"
+                        },
+                        "displayOrder": {
+                            "type": "string"
+                        },
+                        "save": {
+                            "type": "string"
+                        },
+                        "cancel": {
+                            "type": "string"
+                        },
+                        "errors": {
+                            "type": "object",
+                            "properties": {
+                                "invalidName": {
+                                    "type": "string"
+                                },
+                                "labelRequired": {
+                                    "type": "string",
+                                    "description": "Label for a form field or button"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": ["invalidName", "labelRequired"]
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "createTitle",
+                        "editTitle",
+                        "sectionIdentifier",
+                        "sectionDisplay",
+                        "sectionBehavior",
+                        "name",
+                        "nameHint",
+                        "lockedAfterCreate",
+                        "namePlaceholder",
+                        "kind",
+                        "labelFr",
+                        "labelEn",
+                        "descriptionFr",
+                        "descriptionEn",
+                        "displayInForm",
+                        "editableByAdminOnly",
+                        "displayInDetails",
+                        "enableFiltering",
+                        "required",
+                        "displayInCardIcon",
+                        "iconNone",
+                        "displayOrder",
+                        "save",
+                        "cancel",
+                        "errors"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": ["title", "customAttributes", "form"]
         },
         "authorCard": {
             "type": "object",
@@ -1714,11 +1936,22 @@
         "overrideWarningModal": {
             "type": "object",
             "properties": {
-                "title": { "type": "string" },
-                "body": { "type": "string" },
-                "editAtSource": { "type": "string" },
-                "cancel": { "type": "string" },
-                "confirm": { "type": "string" }
+                "title": {
+                    "type": "string",
+                    "description": "Title text"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "editAtSource": {
+                    "type": "string"
+                },
+                "cancel": {
+                    "type": "string"
+                },
+                "confirm": {
+                    "type": "string"
+                }
             },
             "additionalProperties": false,
             "required": ["title", "body", "editAtSource", "cancel", "confirm"]
@@ -1805,6 +2038,7 @@
         "userProfile",
         "header",
         "authButtons",
+        "admin",
         "authorCard",
         "footer",
         "declarationRemovalModal",

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
     <link rel="shortcut icon" href="/dsfr/favicon/favicon.ico" type="image/x-icon" />
     <link rel="manifest" href="/dsfr/favicon/manifest.webmanifest" crossorigin="use-credentials" />
 
-    <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css?hash=fcda3337" />
+    <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css?hash=db12fff5" />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css" />
 
     %VITE_HEAD%

--- a/web/src/core/adapter/sillApi.ts
+++ b/web/src/core/adapter/sillApi.ts
@@ -184,6 +184,30 @@ export function createSillApi(params: { url: string }): SillApi {
             await trpcClient.unreferenceSoftware.mutate(params).catch(errorHandler);
 
             sillApi.getSoftwareList.clear();
+        },
+        getAttributeDefinitions: memoize(
+            () => trpcClient.getAttributeDefinitions.query(),
+            { promise: true }
+        ),
+        createAttributeDefinition: async params => {
+            const out = await trpcClient.createAttributeDefinition
+                .mutate(params)
+                .catch(errorHandler);
+
+            sillApi.getAttributeDefinitions.clear();
+            sillApi.getUiConfig.clear();
+
+            return out;
+        },
+        updateAttributeDefinition: async params => {
+            const out = await trpcClient.updateAttributeDefinition
+                .mutate(params)
+                .catch(errorHandler);
+
+            sillApi.getAttributeDefinitions.clear();
+            sillApi.getUiConfig.clear();
+
+            return out;
         }
     };
 

--- a/web/src/core/ports/SillApi.ts
+++ b/web/src/core/ports/SillApi.ts
@@ -120,6 +120,18 @@ export type SillApi = {
     unreferenceSoftware: (
         params: TrpcRouterInput["unreferenceSoftware"]
     ) => Promise<TrpcRouterOutput["unreferenceSoftware"]>;
+    getAttributeDefinitions: {
+        (
+            params: TrpcRouterInput["getAttributeDefinitions"]
+        ): Promise<TrpcRouterOutput["getAttributeDefinitions"]>;
+        clear: () => void;
+    };
+    createAttributeDefinition: (
+        params: TrpcRouterInput["createAttributeDefinition"]
+    ) => Promise<TrpcRouterOutput["createAttributeDefinition"]>;
+    updateAttributeDefinition: (
+        params: TrpcRouterInput["updateAttributeDefinition"]
+    ) => Promise<TrpcRouterOutput["updateAttributeDefinition"]>;
 };
 
 //NOTE: We make sure we don't forget queries

--- a/web/src/core/usecases/adminAttributes.slice.ts
+++ b/web/src/core/usecases/adminAttributes.slice.ts
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import type { ApiTypes, TrpcRouterInput } from "api";
+import { createSelector, createUsecaseActions } from "redux-clean-architecture";
+import type { State as RootState, Thunks } from "../bootstrap";
+import { id } from "tsafe";
+
+export const name = "adminAttributes";
+
+export type State = {
+    isLoading: boolean;
+    isSaving: boolean;
+    definitions: ApiTypes.AttributeDefinition[];
+};
+
+export const { reducer, actions } = createUsecaseActions({
+    name,
+    initialState: id<State>({
+        isLoading: false,
+        isSaving: false,
+        definitions: []
+    }),
+    reducers: {
+        fetchStarted: state => {
+            state.isLoading = true;
+        },
+        fetchSucceeded: (
+            state,
+            action: { payload: { definitions: ApiTypes.AttributeDefinition[] } }
+        ) => {
+            state.isLoading = false;
+            state.definitions = action.payload.definitions;
+        },
+        fetchFailed: state => {
+            state.isLoading = false;
+        },
+        saveStarted: state => {
+            state.isSaving = true;
+        },
+        saveSettled: state => {
+            state.isSaving = false;
+        }
+    }
+});
+
+const slice = (rootState: RootState) => rootState[name];
+
+export const selectors = {
+    main: createSelector(slice, state => state)
+};
+
+async function refetch(
+    dispatch: Parameters<ReturnType<(typeof thunks)["fetch"]>>[0],
+    sillApi: Parameters<ReturnType<(typeof thunks)["fetch"]>>[2]["sillApi"]
+) {
+    try {
+        const definitions = await sillApi.getAttributeDefinitions();
+        dispatch(actions.fetchSucceeded({ definitions }));
+    } catch {
+        dispatch(actions.fetchFailed());
+    }
+}
+
+export const thunks = {
+    fetch:
+        () =>
+        async (dispatch, _, { sillApi }) => {
+            dispatch(actions.fetchStarted());
+            await refetch(dispatch, sillApi);
+        },
+    create:
+        (params: TrpcRouterInput["createAttributeDefinition"]) =>
+        async (dispatch, _, { sillApi }) => {
+            dispatch(actions.saveStarted());
+            try {
+                await sillApi.createAttributeDefinition(params);
+                await refetch(dispatch, sillApi);
+            } finally {
+                dispatch(actions.saveSettled());
+            }
+        },
+    update:
+        (params: TrpcRouterInput["updateAttributeDefinition"]) =>
+        async (dispatch, _, { sillApi }) => {
+            dispatch(actions.saveStarted());
+            try {
+                await sillApi.updateAttributeDefinition(params);
+                await refetch(dispatch, sillApi);
+            } finally {
+                dispatch(actions.saveSettled());
+            }
+        }
+} satisfies Thunks;

--- a/web/src/core/usecases/index.ts
+++ b/web/src/core/usecases/index.ts
@@ -18,6 +18,7 @@ import * as userProfile from "./userProfile";
 import * as externalDataOrigin from "./externalDataOrigin";
 import * as source from "./source.slice";
 import * as uiConfig from "./uiConfig.slice";
+import * as adminAttributes from "./adminAttributes.slice";
 
 export const usecases = {
     source,
@@ -35,5 +36,6 @@ export const usecases = {
     userAuthentication,
     redirect,
     declarationRemoval,
-    userProfile
+    userProfile,
+    adminAttributes
 };

--- a/web/src/ui/pages/admin/Admin.tsx
+++ b/web/src/ui/pages/admin/Admin.tsx
@@ -110,6 +110,7 @@ function AttributeDefinitionsTable(props: {
         { label: t("admin.customAttributes.columnKind") },
         { label: t("admin.customAttributes.columnLabel") },
         { label: t("admin.customAttributes.columnDisplayInForm"), centered: true },
+        { label: t("admin.customAttributes.columnEditableBy"), centered: true },
         { label: t("admin.customAttributes.columnDisplayInDetails"), centered: true },
         { label: t("admin.customAttributes.columnEnableFiltering"), centered: true },
         { label: t("admin.customAttributes.columnRequired"), centered: true },
@@ -174,6 +175,11 @@ function AttributeDefinitionRow(props: { def: ApiTypes.AttributeDefinition }) {
                 </code>
             </td>
             <td className={classes.cellCentered}>{def.displayInForm ? "✅" : "❌"}</td>
+            <td className={classes.cellCentered}>
+                {def.editableByAdminOnly
+                    ? t("admin.customAttributes.editableByAdminOnly")
+                    : t("admin.customAttributes.editableByEveryone")}
+            </td>
             <td className={classes.cellCentered}>{def.displayInDetails ? "✅" : "❌"}</td>
             <td className={classes.cellCentered}>{def.enableFiltering ? "✅" : "❌"}</td>
             <td className={classes.cellCentered}>{def.required ? "✅" : "❌"}</td>

--- a/web/src/ui/pages/admin/Admin.tsx
+++ b/web/src/ui/pages/admin/Admin.tsx
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useMemo } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { tss } from "tss-react";
+import { assert } from "tsafe/assert";
+import { Equals } from "tsafe";
+import { useTranslation } from "react-i18next";
+import { useCore, useCoreState } from "core";
+import { routes } from "ui/routes";
+import { LoadingFallback } from "ui/shared/LoadingFallback";
+import { useResolveLocalizedString } from "ui/i18n";
+import { iconClassByValue } from "ui/shared/attributeIcons";
+import type { ApiTypes } from "api";
+import type { PageRoute } from "./route";
+import {
+    AttributeDefinitionFormModal,
+    openAttributeDefinitionFormModal
+} from "./AttributeDefinitionFormModal";
+
+type Props = {
+    className?: string;
+    route: PageRoute;
+};
+
+export default function Admin(props: Props) {
+    const { className, route, ...rest } = props;
+
+    /** Assert to make sure all props are deconstructed */
+    assert<Equals<typeof rest, {}>>();
+
+    const { t } = useTranslation();
+    const { classes, cx } = useStyles();
+
+    const { adminAttributes } = useCore().functions;
+    const { currentUser } = useCoreState("userAuthentication", "currentUser");
+    const { isLoading, definitions } = useCoreState("adminAttributes", "main");
+
+    useEffect(() => {
+        if (currentUser?.role !== "admin") {
+            routes.home().replace();
+            return;
+        }
+        adminAttributes.fetch();
+    }, [currentUser?.role]);
+
+    const sortedDefinitions = useMemo(
+        () => [...definitions].sort((a, b) => a.displayOrder - b.displayOrder),
+        [definitions]
+    );
+
+    if (currentUser?.role !== "admin") {
+        return <LoadingFallback />;
+    }
+
+    return (
+        <div className={cx(fr.cx("fr-container--fluid", "fr-px-4w"), className)}>
+            <div className={classes.header}>
+                <h1 className={fr.cx("fr-h2")}>{t("admin.title")}</h1>
+            </div>
+
+            <section className={classes.section}>
+                <div className={classes.sectionHeader}>
+                    <div>
+                        <h2 className={fr.cx("fr-h4")}>
+                            {t("admin.customAttributes.title")}
+                        </h2>
+                        <p className={fr.cx("fr-text--sm", "fr-mb-0")}>
+                            {t("admin.customAttributes.subtitle")}
+                        </p>
+                    </div>
+                    <Button
+                        priority="primary"
+                        iconId="fr-icon-add-line"
+                        onClick={() =>
+                            openAttributeDefinitionFormModal({ mode: "create" })
+                        }
+                    >
+                        {t("admin.customAttributes.addAttribute")}
+                    </Button>
+                </div>
+
+                {isLoading ? (
+                    <LoadingFallback />
+                ) : sortedDefinitions.length === 0 ? (
+                    <p className={fr.cx("fr-text--sm")}>
+                        {t("admin.customAttributes.empty")}
+                    </p>
+                ) : (
+                    <AttributeDefinitionsTable definitions={sortedDefinitions} />
+                )}
+            </section>
+
+            <AttributeDefinitionFormModal />
+        </div>
+    );
+}
+
+function AttributeDefinitionsTable(props: {
+    definitions: ApiTypes.AttributeDefinition[];
+}) {
+    const { definitions } = props;
+    const { t } = useTranslation();
+    const { classes } = useStyles();
+
+    const headers: { label: string; centered?: boolean }[] = [
+        { label: t("admin.customAttributes.columnKind") },
+        { label: t("admin.customAttributes.columnLabel") },
+        { label: t("admin.customAttributes.columnDisplayInForm"), centered: true },
+        { label: t("admin.customAttributes.columnDisplayInDetails"), centered: true },
+        { label: t("admin.customAttributes.columnEnableFiltering"), centered: true },
+        { label: t("admin.customAttributes.columnRequired"), centered: true },
+        { label: t("admin.customAttributes.columnDisplayInCardIcon") },
+        { label: t("admin.customAttributes.columnDisplayOrder"), centered: true },
+        { label: t("admin.customAttributes.columnActions"), centered: true }
+    ];
+
+    return (
+        <div className="fr-table fr-table--bordered">
+            <div className="fr-table__wrapper">
+                <div className="fr-table__container">
+                    <div className="fr-table__content">
+                        <table>
+                            <thead>
+                                <tr>
+                                    {headers.map(({ label, centered }) => (
+                                        <th
+                                            key={label}
+                                            scope="col"
+                                            className={
+                                                centered
+                                                    ? classes.cellCentered
+                                                    : undefined
+                                            }
+                                        >
+                                            {label}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {definitions.map(def => (
+                                    <AttributeDefinitionRow key={def.name} def={def} />
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function AttributeDefinitionRow(props: { def: ApiTypes.AttributeDefinition }) {
+    const { def } = props;
+    const { t } = useTranslation();
+    const { classes, cx } = useStyles();
+    const { resolveLocalizedString } = useResolveLocalizedString();
+
+    const displayLabel = resolveLocalizedString(def.label) || def.name;
+
+    return (
+        <tr>
+            <td>{def.kind}</td>
+            <td className={classes.labelCell}>
+                <div>{displayLabel}</div>
+                <code className={cx(fr.cx("fr-text--xs"), classes.identifier)}>
+                    {def.name}
+                </code>
+            </td>
+            <td className={classes.cellCentered}>{def.displayInForm ? "✅" : "❌"}</td>
+            <td className={classes.cellCentered}>{def.displayInDetails ? "✅" : "❌"}</td>
+            <td className={classes.cellCentered}>{def.enableFiltering ? "✅" : "❌"}</td>
+            <td className={classes.cellCentered}>{def.required ? "✅" : "❌"}</td>
+            <td className={classes.cellCentered}>
+                {def.displayInCardIcon ? (
+                    <i
+                        className={fr.cx(iconClassByValue[def.displayInCardIcon])}
+                        title={def.displayInCardIcon}
+                        aria-label={def.displayInCardIcon}
+                    />
+                ) : (
+                    "—"
+                )}
+            </td>
+            <td className={classes.cellCentered}>{def.displayOrder}</td>
+            <td className={classes.cellCentered}>
+                <Button
+                    priority="tertiary no outline"
+                    iconId="fr-icon-edit-line"
+                    title={t("admin.customAttributes.edit")}
+                    onClick={() =>
+                        openAttributeDefinitionFormModal({
+                            mode: "edit",
+                            definition: def
+                        })
+                    }
+                />
+            </td>
+        </tr>
+    );
+}
+
+const useStyles = tss.withName({ Admin }).create(() => ({
+    header: {
+        marginTop: fr.spacing("6v"),
+        marginBottom: fr.spacing("4v")
+    },
+    section: {
+        marginBottom: fr.spacing("8v")
+    },
+    sectionHeader: {
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "flex-start",
+        gap: fr.spacing("4v"),
+        marginBottom: fr.spacing("4v"),
+        flexWrap: "wrap"
+    },
+    cellCentered: {
+        textAlign: "center"
+    },
+    labelCell: {
+        maxWidth: "28ch",
+        whiteSpace: "normal"
+    },
+    identifier: {
+        opacity: 0.6,
+        wordBreak: "break-all"
+    }
+}));

--- a/web/src/ui/pages/admin/Admin.tsx
+++ b/web/src/ui/pages/admin/Admin.tsx
@@ -57,7 +57,7 @@ export default function Admin(props: Props) {
     }
 
     return (
-        <div className={cx(fr.cx("fr-container--fluid", "fr-px-4w"), className)}>
+        <div className={cx(fr.cx("fr-container"), className)}>
             <div className={classes.header}>
                 <h1 className={fr.cx("fr-h2")}>{t("admin.title")}</h1>
             </div>
@@ -166,7 +166,9 @@ function AttributeDefinitionRow(props: { def: ApiTypes.AttributeDefinition }) {
         <tr>
             <td>{def.kind}</td>
             <td className={classes.labelCell}>
-                <div>{displayLabel}</div>
+                <div className={classes.labelText} title={displayLabel}>
+                    {displayLabel}
+                </div>
                 <code className={cx(fr.cx("fr-text--xs"), classes.identifier)}>
                     {def.name}
                 </code>
@@ -224,8 +226,12 @@ const useStyles = tss.withName({ Admin }).create(() => ({
         textAlign: "center"
     },
     labelCell: {
-        maxWidth: "28ch",
-        whiteSpace: "normal"
+        maxWidth: "32rem"
+    },
+    labelText: {
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap"
     },
     identifier: {
         opacity: 0.6,

--- a/web/src/ui/pages/admin/AttributeDefinitionFormModal.tsx
+++ b/web/src/ui/pages/admin/AttributeDefinitionFormModal.tsx
@@ -50,6 +50,7 @@ type FormState = {
     descriptionFr: string;
     descriptionEn: string;
     displayInForm: boolean;
+    editableByAdminOnly: boolean;
     displayInDetails: boolean;
     enableFiltering: boolean;
     required: boolean;
@@ -74,6 +75,7 @@ function makeInitialState(params: Mode | undefined): FormState {
             descriptionFr: pickLang(def.description, "fr"),
             descriptionEn: pickLang(def.description, "en"),
             displayInForm: def.displayInForm,
+            editableByAdminOnly: def.editableByAdminOnly,
             displayInDetails: def.displayInDetails,
             enableFiltering: def.enableFiltering,
             required: def.required,
@@ -89,6 +91,7 @@ function makeInitialState(params: Mode | undefined): FormState {
         descriptionFr: "",
         descriptionEn: "",
         displayInForm: true,
+        editableByAdminOnly: false,
         displayInDetails: true,
         enableFiltering: false,
         required: false,
@@ -144,6 +147,7 @@ export function AttributeDefinitionFormModal() {
             label: { fr: form.labelFr.trim(), en: form.labelEn.trim() },
             description,
             displayInForm: form.displayInForm,
+            editableByAdminOnly: form.editableByAdminOnly,
             displayInDetails: form.displayInDetails,
             enableFiltering: form.enableFiltering,
             required: form.required,
@@ -300,6 +304,13 @@ export function AttributeDefinitionFormModal() {
                         nativeInputProps: {
                             checked: form.displayInForm,
                             onChange: e => update("displayInForm", e.target.checked)
+                        }
+                    },
+                    {
+                        label: t("admin.form.editableByAdminOnly"),
+                        nativeInputProps: {
+                            checked: form.editableByAdminOnly,
+                            onChange: e => update("editableByAdminOnly", e.target.checked)
                         }
                     },
                     {

--- a/web/src/ui/pages/admin/AttributeDefinitionFormModal.tsx
+++ b/web/src/ui/pages/admin/AttributeDefinitionFormModal.tsx
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { Select } from "@codegouvfr/react-dsfr/Select";
+import { Checkbox } from "@codegouvfr/react-dsfr/Checkbox";
+import { Evt } from "evt";
+import { useRerenderOnStateChange } from "evt/hooks";
+import { useTranslation } from "react-i18next";
+import { tss } from "tss-react";
+import { useCore, useCoreState } from "core";
+import type { ApiTypes, LocalizedString } from "api";
+import {
+    attributeCardIconValues,
+    iconClassByValue,
+    type AttributeCardIcon
+} from "ui/shared/attributeIcons";
+
+const modal = createModal({
+    id: "attribute-definition-form",
+    isOpenedByDefault: false
+});
+
+type Mode =
+    | { mode: "create" }
+    | { mode: "edit"; definition: ApiTypes.AttributeDefinition };
+
+const evtParams = Evt.create<Mode | undefined>(undefined);
+
+evtParams.toStateless().attach(() => modal.open());
+
+export function openAttributeDefinitionFormModal(params: Mode) {
+    evtParams.state = params;
+}
+
+const NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9]*$/;
+
+const KIND_VALUES = ["boolean", "string", "number", "date", "url"] as const;
+
+type FormState = {
+    name: string;
+    kind: ApiTypes.AttributeKind;
+    labelFr: string;
+    labelEn: string;
+    descriptionFr: string;
+    descriptionEn: string;
+    displayInForm: boolean;
+    displayInDetails: boolean;
+    enableFiltering: boolean;
+    required: boolean;
+    displayInCardIcon: "" | AttributeCardIcon;
+    displayOrder: number;
+};
+
+function pickLang(value: LocalizedString | undefined, lang: "fr" | "en"): string {
+    if (value === undefined) return "";
+    if (typeof value === "string") return lang === "fr" ? value : "";
+    return value[lang] ?? "";
+}
+
+function makeInitialState(params: Mode | undefined): FormState {
+    if (params?.mode === "edit") {
+        const def = params.definition;
+        return {
+            name: def.name,
+            kind: def.kind,
+            labelFr: pickLang(def.label, "fr"),
+            labelEn: pickLang(def.label, "en"),
+            descriptionFr: pickLang(def.description, "fr"),
+            descriptionEn: pickLang(def.description, "en"),
+            displayInForm: def.displayInForm,
+            displayInDetails: def.displayInDetails,
+            enableFiltering: def.enableFiltering,
+            required: def.required,
+            displayInCardIcon: def.displayInCardIcon ?? "",
+            displayOrder: def.displayOrder
+        };
+    }
+    return {
+        name: "",
+        kind: "boolean",
+        labelFr: "",
+        labelEn: "",
+        descriptionFr: "",
+        descriptionEn: "",
+        displayInForm: true,
+        displayInDetails: true,
+        enableFiltering: false,
+        required: false,
+        displayInCardIcon: "",
+        displayOrder: 0
+    };
+}
+
+export function AttributeDefinitionFormModal() {
+    const { t } = useTranslation();
+    const { classes } = useStyles();
+    const { adminAttributes } = useCore().functions;
+    const { isSaving } = useCoreState("adminAttributes", "main");
+
+    useRerenderOnStateChange(evtParams);
+    const params = evtParams.state;
+
+    const isEdit = params?.mode === "edit";
+
+    const [form, setForm] = useState<FormState>(() => makeInitialState(params));
+    const [errors, setErrors] = useState<{ name?: string; label?: string }>({});
+
+    useEffect(() => {
+        setForm(makeInitialState(params));
+        setErrors({});
+    }, [params]);
+
+    const update = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+        setForm(prev => ({ ...prev, [key]: value }));
+
+    const submit = async () => {
+        const newErrors: { name?: string; label?: string } = {};
+        if (!isEdit && !NAME_REGEX.test(form.name)) {
+            newErrors.name = t("admin.form.errors.invalidName");
+        }
+        if (!form.labelFr.trim() || !form.labelEn.trim()) {
+            newErrors.label = t("admin.form.errors.labelRequired");
+        }
+        setErrors(newErrors);
+        if (Object.keys(newErrors).length > 0) return;
+
+        const trimDescFr = form.descriptionFr.trim();
+        const trimDescEn = form.descriptionEn.trim();
+        const description =
+            trimDescFr || trimDescEn
+                ? {
+                      ...(trimDescFr && { fr: trimDescFr }),
+                      ...(trimDescEn && { en: trimDescEn })
+                  }
+                : undefined;
+
+        const shared = {
+            label: { fr: form.labelFr.trim(), en: form.labelEn.trim() },
+            description,
+            displayInForm: form.displayInForm,
+            displayInDetails: form.displayInDetails,
+            enableFiltering: form.enableFiltering,
+            required: form.required,
+            displayInCardIcon:
+                form.displayInCardIcon === "" ? undefined : form.displayInCardIcon,
+            displayOrder: form.displayOrder
+        };
+
+        try {
+            if (isEdit) {
+                await adminAttributes.update({ name: form.name, ...shared });
+            } else {
+                await adminAttributes.create({
+                    name: form.name,
+                    kind: form.kind,
+                    ...shared
+                });
+            }
+            modal.close();
+        } catch {
+            /* keep modal open; sillApi.errorHandler already alerted the user */
+        }
+    };
+
+    return (
+        <modal.Component
+            title={isEdit ? t("admin.form.editTitle") : t("admin.form.createTitle")}
+            buttons={[
+                {
+                    doClosesModal: true,
+                    children: t("admin.form.cancel")
+                },
+                {
+                    doClosesModal: false,
+                    onClick: submit,
+                    nativeButtonProps: { disabled: isSaving },
+                    children: t("admin.form.save")
+                }
+            ]}
+        >
+            <h3 className={fr.cx("fr-h6")}>{t("admin.form.sectionIdentifier")}</h3>
+            <Input
+                label={t("admin.form.name")}
+                hintText={
+                    isEdit
+                        ? t("admin.form.nameHint")
+                        : `${t("admin.form.nameHint")} — ${t("admin.form.lockedAfterCreate")}`
+                }
+                disabled={isEdit}
+                state={errors.name ? "error" : "default"}
+                stateRelatedMessage={errors.name}
+                nativeInputProps={{
+                    value: form.name,
+                    onChange: e => update("name", e.target.value),
+                    placeholder: t("admin.form.namePlaceholder")
+                }}
+            />
+            <Select
+                label={t("admin.form.kind")}
+                hint={isEdit ? undefined : t("admin.form.lockedAfterCreate")}
+                disabled={isEdit}
+                nativeSelectProps={{
+                    value: form.kind,
+                    onChange: e =>
+                        update("kind", e.target.value as ApiTypes.AttributeKind)
+                }}
+            >
+                {KIND_VALUES.map(k => (
+                    <option key={k} value={k}>
+                        {k}
+                    </option>
+                ))}
+            </Select>
+
+            <h3 className={fr.cx("fr-h6", "fr-mt-4w")}>
+                {t("admin.form.sectionDisplay")}
+            </h3>
+            <Input
+                label={t("admin.form.labelFr")}
+                state={errors.label ? "error" : "default"}
+                stateRelatedMessage={errors.label}
+                nativeInputProps={{
+                    value: form.labelFr,
+                    onChange: e => update("labelFr", e.target.value)
+                }}
+            />
+            <Input
+                label={t("admin.form.labelEn")}
+                nativeInputProps={{
+                    value: form.labelEn,
+                    onChange: e => update("labelEn", e.target.value)
+                }}
+            />
+            <Input
+                label={t("admin.form.descriptionFr")}
+                textArea
+                nativeTextAreaProps={{
+                    value: form.descriptionFr,
+                    onChange: e => update("descriptionFr", e.target.value)
+                }}
+            />
+            <Input
+                label={t("admin.form.descriptionEn")}
+                textArea
+                nativeTextAreaProps={{
+                    value: form.descriptionEn,
+                    onChange: e => update("descriptionEn", e.target.value)
+                }}
+            />
+            <fieldset className={fr.cx("fr-fieldset")}>
+                <legend className={fr.cx("fr-fieldset__legend")}>
+                    {t("admin.form.displayInCardIcon")}
+                </legend>
+                <div className={`${fr.cx("fr-fieldset__content")} ${classes.iconRow}`}>
+                    <IconChoice
+                        selected={form.displayInCardIcon === ""}
+                        label={t("admin.form.iconNone")}
+                        onClick={() => update("displayInCardIcon", "")}
+                    >
+                        <span aria-hidden="true">—</span>
+                    </IconChoice>
+                    {attributeCardIconValues.map(v => (
+                        <IconChoice
+                            key={v}
+                            selected={form.displayInCardIcon === v}
+                            label={v}
+                            onClick={() => update("displayInCardIcon", v)}
+                        >
+                            <i
+                                className={fr.cx(iconClassByValue[v])}
+                                aria-hidden="true"
+                            />
+                        </IconChoice>
+                    ))}
+                </div>
+            </fieldset>
+            <Input
+                label={t("admin.form.displayOrder")}
+                nativeInputProps={{
+                    type: "number",
+                    value: form.displayOrder,
+                    onChange: e =>
+                        update("displayOrder", Number.parseInt(e.target.value, 10) || 0)
+                }}
+            />
+
+            <h3 className={fr.cx("fr-h6", "fr-mt-4w")}>
+                {t("admin.form.sectionBehavior")}
+            </h3>
+            <Checkbox
+                options={[
+                    {
+                        label: t("admin.form.displayInForm"),
+                        nativeInputProps: {
+                            checked: form.displayInForm,
+                            onChange: e => update("displayInForm", e.target.checked)
+                        }
+                    },
+                    {
+                        label: t("admin.form.displayInDetails"),
+                        nativeInputProps: {
+                            checked: form.displayInDetails,
+                            onChange: e => update("displayInDetails", e.target.checked)
+                        }
+                    },
+                    {
+                        label: t("admin.form.enableFiltering"),
+                        nativeInputProps: {
+                            checked: form.enableFiltering,
+                            onChange: e => update("enableFiltering", e.target.checked)
+                        }
+                    },
+                    {
+                        label: t("admin.form.required"),
+                        nativeInputProps: {
+                            checked: form.required,
+                            onChange: e => update("required", e.target.checked)
+                        }
+                    }
+                ]}
+            />
+        </modal.Component>
+    );
+}
+
+function IconChoice(props: {
+    selected: boolean;
+    label: string;
+    onClick: () => void;
+    children: ReactNode;
+}) {
+    const { selected, label, onClick, children } = props;
+    const { classes, cx } = useStyles();
+    return (
+        <button
+            type="button"
+            title={label}
+            aria-pressed={selected}
+            onClick={onClick}
+            className={cx(
+                fr.cx("fr-btn", "fr-btn--sm", !selected && "fr-btn--tertiary"),
+                classes.iconButton
+            )}
+        >
+            {children}
+        </button>
+    );
+}
+
+const useStyles = tss.withName({ AttributeDefinitionFormModal }).create(() => ({
+    iconRow: {
+        display: "flex",
+        flexWrap: "wrap",
+        gap: fr.spacing("2v")
+    },
+    iconButton: {
+        width: 40,
+        height: 40,
+        padding: 0,
+        justifyContent: "center"
+    }
+}));

--- a/web/src/ui/pages/admin/index.ts
+++ b/web/src/ui/pages/admin/index.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import { lazy } from "react";
+export * from "./route";
+export const LazyComponent = lazy(() => import("./Admin"));

--- a/web/src/ui/pages/admin/route.ts
+++ b/web/src/ui/pages/admin/route.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import { createGroup, defineRoute, createRouter, type Route } from "type-route";
+import { appPath } from "urls";
+
+export const routeDefs = {
+    admin: defineRoute(appPath + "/admin")
+};
+
+export const routeGroup = createGroup(Object.values(createRouter(routeDefs).routes));
+
+export type PageRoute = Route<typeof routeGroup>;
+
+export const getDoRequireUserLoggedIn: (route: PageRoute) => boolean = () => true;

--- a/web/src/ui/pages/index.ts
+++ b/web/src/ui/pages/index.ts
@@ -4,6 +4,7 @@
 
 import * as account from "./account";
 import * as addSoftwareLanding from "./addSoftwareLanding";
+import * as admin from "./admin";
 import * as declarationForm from "./declarationForm";
 import * as home from "./home";
 import * as instanceForm from "./instanceForm";
@@ -23,6 +24,7 @@ import type { UnionToIntersection } from "tsafe";
 export const pages = {
     account,
     addSoftwareLanding,
+    admin,
     declarationForm,
     home,
     instanceForm,

--- a/web/src/ui/pages/softwareForm/CustomAttributeForm.tsx
+++ b/web/src/ui/pages/softwareForm/CustomAttributeForm.tsx
@@ -1,9 +1,11 @@
+import { fr } from "@codegouvfr/react-dsfr";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
 import type { ApiTypes } from "api";
 import type { NonPostableEvt } from "evt";
 import { useEvt } from "evt/hooks";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import type { FieldErrors, UseFormRegister } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useCoreState } from "../../../core";
@@ -22,6 +24,15 @@ export const CustomAttributesForm = ({
     evtActionSubmit: NonPostableEvt<void>;
 }) => {
     const attributeDefinitions = useCoreState("uiConfig", "main")?.attributeDefinitions;
+    const { currentUser } = useCoreState("userAuthentication", "currentUser");
+    const isAdmin = currentUser?.role === "admin";
+    const renderedAttributeDefinitions = useMemo(
+        () =>
+            attributeDefinitions?.filter(
+                def => def.displayInForm && (!def.editableByAdminOnly || isAdmin)
+            ) ?? [],
+        [attributeDefinitions, isAdmin]
+    );
     const [submitButtonElement, setSubmitButtonElement] =
         useState<HTMLButtonElement | null>(null);
 
@@ -40,7 +51,7 @@ export const CustomAttributesForm = ({
         handleSubmit,
         register,
         formState: { errors }
-    } = useForm({
+    } = useForm<ApiTypes.CustomAttributes>({
         defaultValues: initialFormData
     });
 
@@ -51,24 +62,10 @@ export const CustomAttributesForm = ({
             className={className}
             onSubmit={handleSubmit(
                 values => {
-                    const keys = Object.keys(values);
-
-                    const valuesWithCorrectType = keys.reduce((acc, attributeName) => {
-                        const attributeDefinition = attributeDefinitions.find(
-                            def => def.name === attributeName
-                        );
-                        if (!attributeDefinition) return acc;
-                        const rawValue = values[attributeName];
-                        if (rawValue === undefined) return acc;
-
-                        return {
-                            ...acc,
-                            [attributeName]: convertRawAttributeValueToCorrectType({
-                                attributeDefinition,
-                                rawValue
-                            })
-                        } as ApiTypes.CustomAttributes;
-                    }, {} as ApiTypes.CustomAttributes);
+                    const valuesWithCorrectType = getConvertedSubmittedValues({
+                        values,
+                        renderedAttributeDefinitions
+                    });
 
                     console.log({
                         raw: values,
@@ -76,14 +73,23 @@ export const CustomAttributesForm = ({
                         errors: errors
                     });
 
-                    onSubmit(valuesWithCorrectType);
+                    const hiddenInitialValues = getHiddenInitialValues({
+                        attributeDefinitions,
+                        renderedAttributeDefinitions,
+                        initialFormData
+                    });
+
+                    onSubmit({
+                        ...valuesWithCorrectType,
+                        ...hiddenInitialValues
+                    });
                 },
                 err => {
                     console.log("ERROR in form : ", err);
                 }
             )}
         >
-            {attributeDefinitions.map(attributeDefinition => (
+            {renderedAttributeDefinitions.map(attributeDefinition => (
                 <CustomAttributeFormField
                     key={attributeDefinition.name}
                     attributeDefinition={attributeDefinition}
@@ -101,6 +107,56 @@ export const CustomAttributesForm = ({
     );
 };
 
+const getConvertedSubmittedValues = ({
+    values,
+    renderedAttributeDefinitions
+}: {
+    values: ApiTypes.CustomAttributes;
+    renderedAttributeDefinitions: ApiTypes.AttributeDefinition[];
+}): ApiTypes.CustomAttributes => {
+    const convertedValues: ApiTypes.CustomAttributes = {};
+
+    for (const [attributeName, rawValue] of Object.entries(values)) {
+        const attributeDefinition = renderedAttributeDefinitions.find(
+            def => def.name === attributeName
+        );
+        if (!attributeDefinition || rawValue === undefined) continue;
+
+        const convertedValue = convertRawAttributeValueToCorrectType({
+            attributeDefinition,
+            rawValue
+        });
+        if (convertedValue !== undefined) convertedValues[attributeName] = convertedValue;
+    }
+
+    return convertedValues;
+};
+
+const getHiddenInitialValues = ({
+    attributeDefinitions,
+    renderedAttributeDefinitions,
+    initialFormData
+}: {
+    attributeDefinitions: ApiTypes.AttributeDefinition[];
+    renderedAttributeDefinitions: ApiTypes.AttributeDefinition[];
+    initialFormData: ApiTypes.CustomAttributes | undefined;
+}): ApiTypes.CustomAttributes => {
+    const renderedAttributeNames = new Set(
+        renderedAttributeDefinitions.map(def => def.name)
+    );
+    const hiddenInitialValues: ApiTypes.CustomAttributes = {};
+
+    for (const attributeDefinition of attributeDefinitions) {
+        if (renderedAttributeNames.has(attributeDefinition.name)) continue;
+        if (!Object.hasOwn(initialFormData ?? {}, attributeDefinition.name)) continue;
+
+        const value = initialFormData?.[attributeDefinition.name];
+        if (value !== undefined) hiddenInitialValues[attributeDefinition.name] = value;
+    }
+
+    return hiddenInitialValues;
+};
+
 const CustomAttributeFormField = ({
     attributeDefinition,
     initialValue,
@@ -109,16 +165,39 @@ const CustomAttributeFormField = ({
 }: {
     attributeDefinition: ApiTypes.AttributeDefinition;
     initialValue: ApiTypes.AttributeValue | undefined;
-    register: any;
-    errors: any;
+    register: UseFormRegister<ApiTypes.CustomAttributes>;
+    errors: FieldErrors<ApiTypes.CustomAttributes>;
 }) => {
     const { lang } = useLang();
     const { t } = useTranslation();
 
-    const label =
+    const localizedLabel =
         typeof attributeDefinition.label === "string"
             ? attributeDefinition.label
             : attributeDefinition.label[lang];
+    const label = attributeDefinition.editableByAdminOnly ? (
+        <>
+            {localizedLabel}{" "}
+            <span
+                className={fr.cx(
+                    "fr-badge",
+                    "fr-badge--sm",
+                    "fr-badge--yellow-tournesol"
+                )}
+            >
+                <i
+                    className={fr.cx("fr-icon-lock-line", "fr-icon--sm", "fr-mr-1v")}
+                    aria-hidden="true"
+                />
+                {t("softwareForm.adminOnlyCustomAttributeBadge")}
+            </span>
+        </>
+    ) : (
+        localizedLabel
+    );
+    const hintText = attributeDefinition.editableByAdminOnly ? (
+        <strong>{t("softwareForm.adminOnlyCustomAttributeHint")}</strong>
+    ) : undefined;
     const attributeName = attributeDefinition.name;
     const isRequired = attributeDefinition.required;
 
@@ -132,6 +211,7 @@ const CustomAttributeFormField = ({
             return (
                 <Input
                     label={label}
+                    hintText={hintText}
                     state={
                         isRequired && errors[attributeName] !== undefined
                             ? "error"
@@ -150,6 +230,7 @@ const CustomAttributeFormField = ({
             return (
                 <RadioButtons
                     legend={label}
+                    hintText={hintText}
                     state={
                         isRequired && errors[attributeName] !== undefined
                             ? "error"
@@ -210,8 +291,9 @@ const convertRawAttributeValueToCorrectType = ({
             return rawValue !== null ? +rawValue : undefined;
         case "boolean": {
             if (typeof rawValue === "boolean") return rawValue;
-            if ((rawValue as string)?.toLowerCase() === "true") return true;
-            if ((rawValue as string)?.toLowerCase() === "false") return false;
+            if (typeof rawValue !== "string") return undefined;
+            if (rawValue.toLowerCase() === "true") return true;
+            if (rawValue.toLowerCase() === "false") return false;
             if (rawValue === "not applicable") return null;
             return undefined;
         }

--- a/web/src/ui/shared/Header/AuthButtons.tsx
+++ b/web/src/ui/shared/Header/AuthButtons.tsx
@@ -33,6 +33,7 @@ export function AuthButtons(props: Props) {
     const { classes, cx } = useStyles({ isOnPageMyAccount });
 
     const uiConfig = useCoreState("uiConfig", "main")?.uiConfig;
+    const { currentUser } = useCoreState("userAuthentication", "currentUser");
 
     if (!uiConfig?.header.menu.login.enabled) {
         return;
@@ -40,18 +41,16 @@ export function AuthButtons(props: Props) {
 
     if (!userAuthenticationApi.isUserLoggedIn) {
         return (
-            <>
-                <HeaderQuickAccessItem
-                    id={`login-${id}`}
-                    quickAccessItem={{
-                        iconId: "fr-icon-lock-line",
-                        buttonProps: {
-                            onClick: () => userAuthenticationApi.login()
-                        },
-                        text: t("authButtons.login")
-                    }}
-                />
-            </>
+            <HeaderQuickAccessItem
+                id={`login-${id}`}
+                quickAccessItem={{
+                    iconId: "fr-icon-lock-line",
+                    buttonProps: {
+                        onClick: () => userAuthenticationApi.login()
+                    },
+                    text: t("authButtons.login")
+                }}
+            />
         );
     }
 
@@ -73,6 +72,16 @@ export function AuthButtons(props: Props) {
                     } as const
                 }
             />
+            {currentUser?.role === "admin" && (
+                <HeaderQuickAccessItem
+                    id={`admin-${id}`}
+                    quickAccessItem={{
+                        iconId: "fr-icon-shield-line",
+                        linkProps: { ...routes.admin().link },
+                        text: t("authButtons.admin")
+                    }}
+                />
+            )}
             <HeaderQuickAccessItem
                 id={`logout-${id}`}
                 quickAccessItem={{

--- a/web/src/ui/shared/attributeIcons.ts
+++ b/web/src/ui/shared/attributeIcons.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2021-2025 DINUM <floss@numerique.gouv.fr>
+// SPDX-FileCopyrightText: 2024-2025 Université Grenoble Alpes
+// SPDX-License-Identifier: MIT
+
+import type { ApiTypes } from "api";
+import type { FrIconClassName } from "@codegouvfr/react-dsfr/fr/generatedFromCss/classNames";
+
+export type AttributeCardIcon = NonNullable<
+    ApiTypes.AttributeDefinition["displayInCardIcon"]
+>;
+
+export const iconClassByValue: Record<AttributeCardIcon, FrIconClassName> = {
+    computer: "fr-icon-computer-line",
+    france: "fr-icon-france-line",
+    question: "fr-icon-questionnaire-line",
+    "thumbs-up": "fr-icon-thumb-up-line",
+    chat: "fr-icon-chat-2-line",
+    star: "fr-icon-star-line"
+};
+
+export const attributeCardIconValues = Object.keys(
+    iconClassByValue
+) as AttributeCardIcon[];


### PR DESCRIPTION
## Summary
- Adds a `role` column on users (`user` | `admin`, default `user`, promote manually with SQL) and an `adminProcedure` middleware on tRPC.
- New `/admin` page (admin-only) listing `software_attribute_definitions` with create/edit (delete deferred — values are stored in the `softwares.customAttributes` JSONB).
- New web slice `adminAttributes`, shared icon module, conditional shield-icon link in the user menu.

## Bootstrap an admin
Migration only sets the column. Promote a user manually:
```sql
UPDATE users SET role = 'admin' WHERE email = '...';
```

## API surface
| Route | Auth | Notes |
| --- | --- | --- |
| `getAttributeDefinitions` | logged | Read-only list |
| `createAttributeDefinition` | admin | Rejects duplicate `name` and duplicate `displayOrder` (CONFLICT) |
| `updateAttributeDefinition` | admin | `name` and `kind` are not editable |

## Test plan
- [x] `pnpm db:up` (applies migration `1778168171859_add-user-role`)
- [x] `psql … -c "\d users"` shows `role text NOT NULL DEFAULT 'user'` + check constraint
- [x] As a non-admin user: direct call to `createAttributeDefinition` returns FORBIDDEN; `/admin` redirects to home; admin link is hidden
- [x] `UPDATE users SET role='admin' WHERE email='…'` then re-login
- [x] Admin link appears (shield icon, label "Admin"); `/admin` shows the 4 existing definitions with FR labels + identifier underneath
- [x] Edit an attribute: `name` and `kind` are disabled, the rest is editable; saving updates the row
- [x] Create a new `string` attribute `testField` with `displayInForm = true` → appears in the table and in the software-form
- [x] Validation: identifier `123abc` / `with-dash` are rejected; reusing an existing `displayOrder` returns a CONFLICT alert
- [x] `pnpm fullcheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)