### PR TITLE
feat: block createSoftware API when addSoftwareOrService use case is disabled

### DIFF
--- a/api/src/core/usecases/refreshExternalData.test.ts
+++ b/api/src/core/usecases/refreshExternalData.test.ts
@@ -210,6 +210,7 @@ describe("fetches software extra data (from different providers)", () => {
             .selectFrom("software_external_datas")
             .selectAll()
             .orderBy("softwareId", "asc")
+            .orderBy("sourceSlug", "asc")
             .execute();
 
         expectToMatchObject(softwareExternalDatas, initialExternalSoftwarePackagesBeforeFetching);
@@ -220,6 +221,7 @@ describe("fetches software extra data (from different providers)", () => {
             .selectFrom("software_external_datas")
             .selectAll()
             .orderBy("softwareId", "asc")
+            .orderBy("sourceSlug", "asc")
             .execute();
 
         expectToEqual(updatedSoftwareExternalDatas, initialExternalSoftwarePackagesBeforeFetching);

--- a/api/src/rpc/createTestCaller.ts
+++ b/api/src/rpc/createTestCaller.ts
@@ -10,10 +10,12 @@ import { Session } from "../core/ports/DbApiV2";
 import { testPgUrl } from "../tools/test.helpers";
 import { createRouter } from "./router";
 import { UserWithId } from "../lib/ApiTypes";
+import { UiConfig } from "../core/uiConfigSchema";
 
 type TestCallerConfig = {
     currentUser: UserWithId | undefined;
     db?: Kysely<Database>;
+    overrideUiConfig?: (uiConfig: UiConfig) => UiConfig;
 };
 
 export const defaultUser: UserWithId = {
@@ -29,7 +31,9 @@ export const defaultUser: UserWithId = {
 
 export type ApiCaller = Awaited<ReturnType<typeof createTestCaller>>["apiCaller"];
 
-export const createTestCaller = async ({ currentUser, db }: TestCallerConfig = { currentUser: defaultUser }) => {
+export const createTestCaller = async (
+    { currentUser, db, overrideUiConfig }: TestCallerConfig = { currentUser: defaultUser }
+) => {
     const kyselyDb = db ?? new Kysely<Database>({ dialect: createPgDialect(testPgUrl) });
 
     const { dbApi, useCases, uiConfig } = await bootstrapCore({
@@ -54,7 +58,7 @@ export const createTestCaller = async ({ currentUser, db }: TestCallerConfig = {
             appUrl: "http://localhost:3000"
         },
         redirectUrl: undefined,
-        uiConfig
+        uiConfig: overrideUiConfig ? overrideUiConfig(uiConfig) : uiConfig
     });
 
     if (currentUser) {

--- a/api/src/rpc/router.ts
+++ b/api/src/rpc/router.ts
@@ -221,6 +221,13 @@ export function createRouter(params: {
             .mutation(async ({ ctx: { currentUser }, input }) => {
                 const { formData } = input;
 
+                if (!uiConfig.home.usecases.addSoftwareOrService.enabled && currentUser.role !== "admin") {
+                    throw new TRPCError({
+                        "code": "FORBIDDEN",
+                        "message": "Adding software is disabled"
+                    });
+                }
+
                 try {
                     const sanitizedFormData = await sanitizeSoftwareFormDataCustomAttributes({
                         dbApi,

--- a/api/src/rpc/routes.e2e.test.ts
+++ b/api/src/rpc/routes.e2e.test.ts
@@ -115,6 +115,63 @@ describe("RPC e2e tests", () => {
         });
     });
 
+    describe("createSoftware - when adding software is disabled in ui-config", () => {
+        const disableAddSoftware: NonNullable<
+            Parameters<typeof createTestCaller>[0]
+        >["overrideUiConfig"] = uiConfig => ({
+            ...uiConfig,
+            home: {
+                ...uiConfig.home,
+                usecases: {
+                    ...uiConfig.home.usecases,
+                    addSoftwareOrService: {
+                        ...uiConfig.home.usecases.addSoftwareOrService,
+                        enabled: false
+                    }
+                }
+            }
+        });
+
+        it("fails with FORBIDDEN for a regular user", async () => {
+            ({ kyselyDb } = await createTestCaller({ currentUser: undefined }));
+            await resetDB(kyselyDb);
+            ({ apiCaller, kyselyDb } = await createTestCaller({
+                db: kyselyDb,
+                currentUser: defaultUser,
+                overrideUiConfig: disableAddSoftware
+            }));
+            await expect(
+                apiCaller.createSoftware({
+                    formData: softwareFormData
+                })
+            ).rejects.toThrow("Adding software is disabled");
+        });
+
+        it("still allows an admin to create a software", async () => {
+            ({ kyselyDb } = await createTestCaller({ currentUser: undefined }));
+            await resetDB(kyselyDb);
+            ({ apiCaller, kyselyDb } = await createTestCaller({
+                db: kyselyDb,
+                currentUser: adminUser,
+                overrideUiConfig: disableAddSoftware
+            }));
+            await apiCaller.createSoftware({
+                formData: createSoftwareFormData({
+                    sourceSlug: testSource.slug,
+                    name: "Admin create while disabled test",
+                    similarSoftwareExternalDataItems: []
+                })
+            });
+
+            const software = await kyselyDb
+                .selectFrom("softwares")
+                .select("name")
+                .where("name", "=", "Admin create while disabled test")
+                .executeTakeFirstOrThrow();
+            expect(software.name).toBe("Admin create while disabled test");
+        });
+    });
+
     describe("admin-only custom attributes", () => {
         const insertAttributeDefinition = async (params: {
             name: string;


### PR DESCRIPTION
## Problème

Quand l'ajout de logiciel est désactivé dans `ui-config.json` (`home.usecases.addSoftwareOrService.enabled: false`), seuls les points d'entrée web sont masqués (menu header, tuile home). L'API `createSoftware` reste accessible à tout utilisateur authentifié.

## Solution

- La mutation `createSoftware` renvoie `FORBIDDEN` quand le flag est désactivé, sauf pour les admins.
- `createTestCaller` accepte un `overrideUiConfig` optionnel pour les tests.
- Tests e2e : utilisateur normal → FORBIDDEN ; admin → création autorisée malgré le flag off.

Pas de changement de schéma ui-config : les déploiements avec fichier custom (sill-deploy) sont compatibles tels quels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)